### PR TITLE
Use pkgconfig to find libplist and dnssd

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,15 @@ if( UNIX AND NOT APPLE )
  add_definitions( -DSUPPRESS_AVAHI_COMPAT_WARNING )
 endif()
 
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(DNSSD REQUIRED avahi-compat-libdns_sd)
+pkg_check_modules(PLIST REQUIRED libplist-2.0)
+if(NOT PLIST_FOUND)
+  pkg_check_modules(PLIST REQUIRED libplist)
+endif()
+
+link_directories(${PLIST_LIBRARY_DIRS})
+
 add_subdirectory( lib/llhttp )
 add_subdirectory( lib/playfair )
 add_subdirectory( lib )
@@ -40,14 +49,10 @@ else()
                   )
 endif()
 
-if (BSD )
-  target_link_directories( uxplay PUBLIC /usr/local/lib )
-  target_link_libraries( uxplay ${PLIST_LIBRARIES})
-endif() 
-
 target_link_libraries( uxplay
                    renderers
                    airplay
+                   ${PLIST_LIBRARIES}
 		   )
 
 install( TARGETS  uxplay RUNTIME DESTINATION bin )

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Make sure that cmake>=3.4.1 and pkg-config are also installed: "sudo apt-get ins
 In a terminal window, change directories to the source directory of the
 downloaded source code ("UxPlay-master" for zipfile downloads, "UxPlay" for "git clone" downloads), then do
 
-1. `sudo apt-get install libssl-dev libplist-dev libavahi-compat-libdnssd-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev gstreamer1.0-libav gstreamer1.0-plugins-bad` 
+1. `sudo apt-get install libssl-dev libplist-dev libavahi-compat-libdnssd-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev gstreamer1.0-libav gstreamer1.0-plugins-bad libavahi-compat-libdnssd-dev`
 2. `sudo apt-get install gstreamer1.0-vaapi` (For Intel graphics, but not nVidia graphics)
 3. `sudo apt-get install libx11-dev`  (for the "ZOOMFIX" X11_display name fix for screen-sharing with e.g.,  ZOOM)
 4. `cmake .` (or "`cmake -DZOOMFIX=ON .`" to get a screen-sharing fix to


### PR DESCRIPTION
Builds OK on Linux and avoids hard coding `/usr/local/lib` and special casing.