### PR TITLE
fix assert(f()>=0) in Release Version

### DIFF
--- a/lib/raop_rtp.c
+++ b/lib/raop_rtp.c
@@ -521,7 +521,7 @@ raop_rtp_thread_udp(void *arg)
                     uint32_t timestamp = byteutils_get_int_be(resent_packet, 4);
                     uint64_t rtp_time = rtp64_time(raop_rtp, &timestamp);
                     logger_log(raop_rtp->logger, LOGGER_DEBUG, "raop_rtp resent audio packet: seqnum=%u", seqnum);
-		    int enqueue_ret = raop_buffer_enqueue(raop_rtp->buffer, resent_packet, resent_packetlen, rtp_time, 1);
+		            int enqueue_ret = raop_buffer_enqueue(raop_rtp->buffer, resent_packet, resent_packetlen, rtp_time, 1);
                     assert(enqueue_ret >= 0);
                 } else {
                     /* type_c = 0x56 packets  with length 8 have been reported */
@@ -658,11 +658,11 @@ raop_rtp_thread_udp(void *arg)
                         raop_rtp->rtp_sync_offset = initial_offset + (int64_t) (sync_adjustment / rtp_count);
                         //logger_log(raop_rtp->logger, LOGGER_DEBUG, "initial estimate of rtp_sync_offset %d secnum = %u:  %8.6f",
                         //           rtp_count, seqnum,  ((double) raop_rtp->rtp_sync_offset) / SEC);
-		    }
+		            }
                     seqnum2 = seqnum1;
                     seqnum1 = seqnum;
                 }
-		int enqueue_ret = raop_buffer_enqueue(raop_rtp->buffer, resent_packet, resent_packetlen, rtp_time, 1);
+		        int enqueue_ret = raop_buffer_enqueue(raop_rtp->buffer, packet, packetlen, rtp_time, 1);
                 assert(enqueue_ret >= 0);
                 // Render continuous buffer entries
                 void *payload = NULL;

--- a/lib/raop_rtp.c
+++ b/lib/raop_rtp.c
@@ -658,7 +658,7 @@ raop_rtp_thread_udp(void *arg)
                         raop_rtp->rtp_sync_offset = initial_offset + (int64_t) (sync_adjustment / rtp_count);
                         //logger_log(raop_rtp->logger, LOGGER_DEBUG, "initial estimate of rtp_sync_offset %d secnum = %u:  %8.6f",
                         //           rtp_count, seqnum,  ((double) raop_rtp->rtp_sync_offset) / SEC);
-		            }
+                    }
                     seqnum2 = seqnum1;
                     seqnum1 = seqnum;
                 }

--- a/lib/raop_rtp.c
+++ b/lib/raop_rtp.c
@@ -521,7 +521,8 @@ raop_rtp_thread_udp(void *arg)
                     uint32_t timestamp = byteutils_get_int_be(resent_packet, 4);
                     uint64_t rtp_time = rtp64_time(raop_rtp, &timestamp);
                     logger_log(raop_rtp->logger, LOGGER_DEBUG, "raop_rtp resent audio packet: seqnum=%u", seqnum);
-                    assert(raop_buffer_enqueue(raop_rtp->buffer, resent_packet, resent_packetlen, rtp_time, 1) >= 0);
+		    int enqueue_ret = raop_buffer_enqueue(raop_rtp->buffer, resent_packet, resent_packetlen, rtp_time, 1);
+                    assert(enqueue_ret >= 0);
                 } else {
                     /* type_c = 0x56 packets  with length 8 have been reported */
                     char *str = utils_data_to_string(packet, packetlen, 16);
@@ -661,7 +662,8 @@ raop_rtp_thread_udp(void *arg)
                     seqnum2 = seqnum1;
                     seqnum1 = seqnum;
                 }
-                assert(raop_buffer_enqueue(raop_rtp->buffer, packet, packetlen, rtp_time, 1) >= 0);
+		int enqueue_ret = raop_buffer_enqueue(raop_rtp->buffer, resent_packet, resent_packetlen, rtp_time, 1);
+                assert(enqueue_ret >= 0);
                 // Render continuous buffer entries
                 void *payload = NULL;
                 unsigned int payload_size;

--- a/lib/raop_rtp.c
+++ b/lib/raop_rtp.c
@@ -521,7 +521,7 @@ raop_rtp_thread_udp(void *arg)
                     uint32_t timestamp = byteutils_get_int_be(resent_packet, 4);
                     uint64_t rtp_time = rtp64_time(raop_rtp, &timestamp);
                     logger_log(raop_rtp->logger, LOGGER_DEBUG, "raop_rtp resent audio packet: seqnum=%u", seqnum);
-		            int enqueue_ret = raop_buffer_enqueue(raop_rtp->buffer, resent_packet, resent_packetlen, rtp_time, 1);
+                    int enqueue_ret = raop_buffer_enqueue(raop_rtp->buffer, resent_packet, resent_packetlen, rtp_time, 1);
                     assert(enqueue_ret >= 0);
                 } else {
                     /* type_c = 0x56 packets  with length 8 have been reported */
@@ -662,7 +662,7 @@ raop_rtp_thread_udp(void *arg)
                     seqnum2 = seqnum1;
                     seqnum1 = seqnum;
                 }
-		        int enqueue_ret = raop_buffer_enqueue(raop_rtp->buffer, packet, packetlen, rtp_time, 1);
+                int enqueue_ret = raop_buffer_enqueue(raop_rtp->buffer, packet, packetlen, rtp_time, 1);
                 assert(enqueue_ret >= 0);
                 // Render continuous buffer entries
                 void *payload = NULL;


### PR DESCRIPTION
fix assert(fuc()>=0) will be ignore in release version
in visual studio 2017 Release
assert(raop_buffer_enqueue(raop_rtp->buffer, packet, packetlen, rtp_time, 1) >= 0);
can't running raop_buffer_enqueue(raop_rtp->buffer, packet, packetlen, rtp_time, 1);
so ,I can't using my application play audio

I fixed this problem in my winrpiplay https://github.com/heweisheng/WinRPiPlay