### PR TITLE
Add Windows implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 build/
 .vscode/
+cmake-build-*/
+.idea/

--- a/BUILD_WINDOWS.md
+++ b/BUILD_WINDOWS.md
@@ -19,15 +19,7 @@ pacman -S mingw-w64-x86_64-gcc mingw-w64-x86_64-cmake mingw-w64-x86_64-libplist 
     mingw-w64-x86_64-gst-plugins-ugly \
     git
 ```
-#### Build and install kdewin:
-```
-export PATH="/mingw64/bin/:$PATH"
-git clone https://github.com/KDE/kdewin.git --depth=1
-cd kdewin; mkdir build; cd build
-cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/mingw64/ -DBUILD_QT_LIB=OFF -DBUILD_BASE_LIB_WITH_QT=OFF -DSTATIC_LIBRARY=ON ..
-ninja
-ninja install
-```
+
 Add permanently mingw64 in MSYS2 PATH:
 ```
 echo 'export PATH="/mingw64/bin/:$PATH"' >> ~/.bashrc

--- a/BUILD_WINDOWS.md
+++ b/BUILD_WINDOWS.md
@@ -1,0 +1,38 @@
+## Building UxPlay on Windows with MinGW-w64:
+
+### Download and install dependencies:
+Download MSYS2 from official site: https://www.msys2.org/
+
+Download **Bonjour SDK for Windows v3.0** from official Apple site: https://developer.apple.com/download/all/?q=Bonjour%20SDK%20for%20Windows 
+
+### Install dependencies in MSYS2:
+Open **MSYS2 MSYS** and install required packages:
+```
+pacman -S mingw-w64-x86_64-gcc mingw-w64-x86_64-cmake mingw-w64-x86_64-libplist \
+    mingw-w64-x86_64-gstreamer \
+    mingw-w64-x86_64-gst-libav \
+    mingw-w64-x86_64-gst-plugins-bad \
+    mingw-w64-x86_64-gst-plugins-bad-libs \
+    mingw-w64-x86_64-gst-rtsp-server \
+    mingw-w64-x86_64-gst-plugins-base \
+    mingw-w64-x86_64-gst-plugins-good \
+    mingw-w64-x86_64-gst-plugins-ugly \
+    git
+```
+#### Build and install kdewin:
+```
+echo 'export PATH="/mingw64/bin/:$PATH"' >> ~/.bashrc
+
+export PATH="/mingw64/bin/:$PATH"
+git clone https://github.com/KDE/kdewin.git --depth=1
+cd kdewin; mkdir build; cd build
+cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/mingw64/ -DBUILD_QT_LIB=OFF -DBUILD_BASE_LIB_WITH_QT=OFF -DSTATIC_LIBRARY=ON ..
+ninja
+ninja install
+```
+
+
+Now you can add **MinGW-w64** compiler installed from MSYS2 to your IDE. Compiler with all required dependencies located in msys64 directory, by default this path `C:/msys64/mingw64`. Also you can build UxPlay using MSYS2 environment.
+
+### Known issues:
+* No sound

--- a/BUILD_WINDOWS.md
+++ b/BUILD_WINDOWS.md
@@ -21,8 +21,6 @@ pacman -S mingw-w64-x86_64-gcc mingw-w64-x86_64-cmake mingw-w64-x86_64-libplist 
 ```
 #### Build and install kdewin:
 ```
-echo 'export PATH="/mingw64/bin/:$PATH"' >> ~/.bashrc
-
 export PATH="/mingw64/bin/:$PATH"
 git clone https://github.com/KDE/kdewin.git --depth=1
 cd kdewin; mkdir build; cd build
@@ -30,7 +28,10 @@ cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/mingw64/ -DBUILD_QT_LIB
 ninja
 ninja install
 ```
-
+Add permanently mingw64 in MSYS2 PATH:
+```
+echo 'export PATH="/mingw64/bin/:$PATH"' >> ~/.bashrc
+```
 
 Now you can add **MinGW-w64** compiler installed from MSYS2 to your IDE. Compiler with all required dependencies located in msys64 directory, by default this path `C:/msys64/mingw64`. Also you can build UxPlay using MSYS2 environment.
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,10 +26,19 @@ add_subdirectory( lib/playfair )
 add_subdirectory( lib )
 add_subdirectory( renderers )
 
+if( MINGW )
+    find_package( PkgConfig REQUIRED )
+    pkg_check_modules( KDEWIN REQUIRED kdewin>=0.6.3 )
+    include_directories( ${KDEWIN_INCLUDE_DIRS} )
+    find_library( LIBKDEWIN ${KDEWIN_LIBRARIES} PATH ${KDEWIN_LIBDIR} )
+    set( OS_DEPENDENT_LIBRARIES ${LIBKDEWIN} )
+endif()
+
 add_executable( uxplay uxplay.cpp )
 target_link_libraries( uxplay
                    renderers
                    airplay
+                   ${OS_DEPENDENT_LIBRARIES}
 		   )
 
 install( TARGETS  uxplay RUNTIME DESTINATION bin )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,6 @@ add_executable( uxplay uxplay.cpp )
 target_link_libraries( uxplay
                    renderers
                    airplay
-                   ${OS_DEPENDENT_LIBRARIES}
 		   )
 
 install( TARGETS  uxplay RUNTIME DESTINATION bin )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,14 +26,6 @@ add_subdirectory( lib/playfair )
 add_subdirectory( lib )
 add_subdirectory( renderers )
 
-if( MINGW )
-    find_package( PkgConfig REQUIRED )
-    pkg_check_modules( KDEWIN REQUIRED kdewin>=0.6.3 )
-    include_directories( ${KDEWIN_INCLUDE_DIRS} )
-    find_library( LIBKDEWIN ${KDEWIN_LIBRARIES} PATH ${KDEWIN_LIBDIR} )
-    set( OS_DEPENDENT_LIBRARIES ${LIBKDEWIN} )
-endif()
-
 add_executable( uxplay uxplay.cpp )
 target_link_libraries( uxplay
                    renderers

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -61,11 +61,6 @@ else()
           llhttp )
 endif()
 
-if( MINGW )
-  pkg_check_modules( KDEWIN REQUIRED kdewin>=0.6.3 )
-  target_include_directories( airplay PRIVATE ${KDEWIN_INCLUDE_DIRS} )
-endif()
-
 # libplist
 if( (UNIX OR MINGW) AND NOT APPLE )
   pkg_search_module(PLIST libplist>=2.0)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.4.1)
 include_directories( playfair llhttp )
 
 # Common Linux cflags
-if ( UNIX AND NOT APPLE )
+if ( (UNIX OR MINGW) AND NOT APPLE )
   set( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DSTANDALONE -D__STDC_CONSTANT_MACROS -D__STDC_LIMIT_MACROS -DTARGET_POSIX -D_LINUX -fPIC -DPIC -D_REENTRANT -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -U_FORTIFY_SOURCE -Wall -g" )
 endif()
 
@@ -47,15 +47,27 @@ if ( APPLE )
                          pthread
                          playfair
                          llhttp )
-else()
+elseif( MINGW )
   target_link_libraries( airplay PUBLIC 
                          pthread
                          playfair
-                         llhttp )
+                         llhttp
+                         wsock32
+                         ws2_32 )
+else()
+  target_link_libraries( airplay PUBLIC
+          pthread
+          playfair
+          llhttp )
+endif()
+
+if( MINGW )
+  pkg_check_modules( KDEWIN REQUIRED kdewin>=0.6.3 )
+  target_include_directories( airplay PRIVATE ${KDEWIN_INCLUDE_DIRS} )
 endif()
 
 # libplist
-if( UNIX AND NOT APPLE )
+if( (UNIX OR MINGW) AND NOT APPLE )
   pkg_search_module(PLIST libplist>=2.0)
   if(NOT PLIST_FOUND)
     pkg_search_module(PLIST REQUIRED libplist-2.0)
@@ -72,7 +84,7 @@ endif()
 target_include_directories( airplay PRIVATE ${PLIST_INCLUDE_DIRS} )
 
 #libcrypto
-if( UNIX AND NOT APPLE )
+if( (UNIX OR MINGW) AND NOT APPLE )
   find_package(OpenSSL 1.1.1 REQUIRED)
   target_compile_definitions( airplay PUBLIC OPENSSL_API_COMPAT=0x10101000L )
   target_link_libraries( airplay PUBLIC OpenSSL::Crypto )
@@ -95,18 +107,24 @@ elseif( APPLE )
 endif()
 
 #dns_sd 
-if ( UNIX AND NOT APPLE )
+if ( (UNIX OR MINGW) AND NOT APPLE )
   pkg_search_module(AVAHI_DNSSD avahi-compat-libdns_sd)
   if (AVAHI_DNSSD_FOUND)
     target_include_directories( airplay PRIVATE ${AVAHI_DNSSD_INCLUDE_DIRS} )
     find_library( DNSSD ${AVAHI_DNSSD_LIBRARIES} PATH ${AVAHI_DNSSD_LIBDIR})
   else()  # UxPlay can also build if mDNSResponder or another implementation of dns_sd is present instead of Avahi
-    find_library( DNSSD dns_sd )
-    if( NOT DNSSD )
-      message( FATAL_ERROR "libdns_sd missing; can be provided by avahi_compat-libdns_sd or mDNSResponder." )
+    if ( MINGW )
+      set(DNSSD "C:/Program Files/Bonjour SDK/Lib/x64/dnssd.lib")
+      set(DNSSD_INCLUDE_DIR "C:/Program Files/Bonjour SDK/Include")
     else()
-      message( STATUS "dns_sd:  found" ${DNSSD} )
+      find_library( DNSSD dns_sd )
+      if( NOT DNSSD )
+        message( FATAL_ERROR "libdns_sd missing; can be provided by avahi_compat-libdns_sd or mDNSResponder." )
+      else()
+        message( STATUS "dns_sd:  found" ${DNSSD} )
+      endif()
     endif()
+
     find_path(DNSSD_INCLUDE_DIR dns_sd.h HINTS ${CMAKE_INSTALL_INCLUDEDIR} )
     if ( NOT DNSSD_INCLUDE_DIR )
       message( FATAL_ERROR " dns_sd.h not found ")

--- a/lib/byteutils.c
+++ b/lib/byteutils.c
@@ -20,10 +20,20 @@
 #ifdef SYS_ENDIAN_H
 #include <sys/endian.h>
 #else
+
+#ifndef __MINGW64__
 #include <endian.h>
 #endif
+
+#endif
+
 #define htonll(x) htobe64(x)
 #define ntohll(x) be64toh(x)
+
+#ifdef __MINGW64__
+#define be64toh(x) ((1==ntohl(1)) ? (x) : (((uint64_t)ntohl((x) & 0xFFFFFFFFUL)) << 32) | ntohl((uint32_t)((x) >> 32)))
+#endif
+
 #endif
 
 // The functions in this file assume a little endian cpu architecture!

--- a/lib/byteutils.c
+++ b/lib/byteutils.c
@@ -13,7 +13,13 @@
  */
 
 #include <time.h>
+
+#ifdef __MINGW64__
+#include <winsock2.h>
+#else
 #include <netinet/in.h>
+#endif
+
 #include "byteutils.h"
 
 #ifndef htonll

--- a/lib/dnssd.c
+++ b/lib/dnssd.c
@@ -60,8 +60,9 @@
 # endif
 
 typedef struct _DNSServiceRef_t *DNSServiceRef;
+#ifndef __MINGW64__
 typedef union _TXTRecordRef_t { char PrivateData[16]; char *ForceNaturalAlignment; } TXTRecordRef;
-
+#endif
 typedef uint32_t DNSServiceFlags;
 typedef int32_t  DNSServiceErrorType;
 

--- a/lib/raop_rtp_mirror.c
+++ b/lib/raop_rtp_mirror.c
@@ -32,6 +32,15 @@
 #include "utils.h"
 #include "plist/plist.h"
 
+#ifdef __MINGW64__
+#include "ws2ipdef.h"
+
+#define TCP_KEEPIDLE SO_KEEPALIVE
+#define TCP_KEEPINTVL SO_KEEPALIVE
+#define TCP_KEEPCNT SO_KEEPALIVE
+
+#endif
+
 #define SEC 1000000
 /* for MacOS, where SOL_TCP and TCP_KEEPIDLE are not defined */
 #if !defined(SOL_TCP) && defined(IPPROTO_TCP)

--- a/lib/raop_rtp_mirror.c
+++ b/lib/raop_rtp_mirror.c
@@ -20,7 +20,10 @@
 #include <assert.h>
 #include <errno.h>
 #include <stdbool.h>
+
+#ifndef __MINGW64__
 #include <netinet/tcp.h>
+#endif
 
 #include "raop.h"
 #include "netutils.h"

--- a/lib/threads.h
+++ b/lib/threads.h
@@ -15,27 +15,6 @@
 #ifndef THREADS_H
 #define THREADS_H
 
-#if defined(WIN32)
-#include <windows.h>
-
-#define sleepms(x) Sleep(x)
-
-typedef HANDLE thread_handle_t;
-
-#define THREAD_RETVAL DWORD WINAPI
-#define THREAD_CREATE(handle, func, arg) \
-	handle = CreateThread(NULL, 0, func, arg, 0, NULL)
-#define THREAD_JOIN(handle) do { WaitForSingleObject(handle, INFINITE); CloseHandle(handle); } while(0)
-
-typedef HANDLE mutex_handle_t;
-
-#define MUTEX_CREATE(handle) handle = CreateMutex(NULL, FALSE, NULL)
-#define MUTEX_LOCK(handle) WaitForSingleObject(handle, INFINITE)
-#define MUTEX_UNLOCK(handle) ReleaseMutex(handle)
-#define MUTEX_DESTROY(handle) CloseHandle(handle)
-
-#else /* Use pthread library */
-
 #include <pthread.h>
 #include <unistd.h>
 
@@ -60,7 +39,5 @@ typedef pthread_cond_t cond_handle_t;
 #define COND_CREATE(handle) pthread_cond_init(&(handle), NULL)
 #define COND_SIGNAL(handle) pthread_cond_signal(&(handle))
 #define COND_DESTROY(handle) pthread_cond_destroy(&(handle))
-
-#endif
 
 #endif /* THREADS_H */

--- a/uxplay.cpp
+++ b/uxplay.cpp
@@ -24,16 +24,18 @@
 #include <string>
 #include <vector>
 #include <fstream>
-#include <sys/utsname.h>
+
 #ifdef __MINGW64__
 #include <glib.h>
 #include <unordered_map>
+#include <windows.h>
 #else
 #include <glib-unix.h>
-#endif
-
+#include <sys/utsname.h>
 #include <sys/socket.h>
 #include <ifaddrs.h>
+#endif
+
 #ifdef __linux__
 #include <netpacket/packet.h>
 #else
@@ -516,6 +518,16 @@ static bool get_videorotate (const char *str, videoflip_t *videoflip) {
 }
 
 static void append_hostname(std::string &server_name) {
+#ifdef __MINGW64__
+    char buffer[256] = "";
+    unsigned long size = sizeof(buffer);
+    if (GetComputerNameA(buffer, &size)) {
+      std::string name = server_name;
+      name.append("@");
+      name.append(buffer);
+      server_name = name;
+    }
+#else
     struct utsname buf;
     if (!uname(&buf)) {
       std::string name = server_name;
@@ -523,6 +535,7 @@ static void append_hostname(std::string &server_name) {
       name.append(buf.nodename);
       server_name = name;
     }
+#endif
 }
 
 void parse_arguments (int argc, char *argv[]) {    


### PR DESCRIPTION
Added Windows implementation for MinGW64 compiler.

### For now sound does not work on Windows
On environment all required plugins has installed (wasapisrc or directsoundsrc dlls presents). When I manually set any Windows supported audiosink (using -as argument) the following error appears:
```
gst_parse_launch error (audio 1):
 no property "sync" in element "wasapisrc0"
```
When I remove `g_string_append (launch, " sync=false")`:
```
gst_parse_launch error (audio 1):
 could not link level0 to wasapisrc0
```

With `autoaudiosink` as audiosink other errors (gstream warnings) apeared. I will take a look this issue