### PR TITLE
add F11 shortcut to toggle into fullscreen mode

### DIFF
--- a/renderers/video_renderer_gstreamer.c
+++ b/renderers/video_renderer_gstreamer.c
@@ -222,7 +222,6 @@ void video_renderer_render_buffer(raop_ntp_t *ntp, unsigned char* data, int data
         if (renderer->gst_window && !(renderer->gst_window->window)) {
             fix_x_window_name(renderer->gst_window, renderer->server_name);
         }
-
 #endif
     }
 }
@@ -264,8 +263,6 @@ void video_renderer_destroy() {
 void video_renderer_update_background(int type) {
 }
 
-
-
 gboolean gstreamer_pipeline_bus_callback(GstBus *bus, GstMessage *message, gpointer loop) {
     switch (GST_MESSAGE_TYPE (message)) {
     case GST_MESSAGE_ERROR: {
@@ -283,13 +280,13 @@ gboolean gstreamer_pipeline_bus_callback(GstBus *bus, GstMessage *message, gpoin
                      "*** Try using option -avdec to force software decoding or use -vs <videosink>\n"
                      "*** to select a videosink of your choice (see \"man uxplay\")");
         }
-	    g_error_free (err);
+	g_error_free (err);
         g_free (debug);
         gst_app_src_end_of_stream (GST_APP_SRC(renderer->appsrc));
-	    flushing = TRUE;
+	flushing = TRUE;
         gst_bus_set_flushing(bus, flushing);
- 	    gst_element_set_state (renderer->pipeline, GST_STATE_NULL);
-	    g_main_loop_quit( (GMainLoop *) loop);
+ 	gst_element_set_state (renderer->pipeline, GST_STATE_NULL);
+	g_main_loop_quit( (GMainLoop *) loop);
         break;
     }
     case GST_MESSAGE_EOS:
@@ -325,7 +322,7 @@ gboolean gstreamer_pipeline_bus_callback(GstBus *bus, GstMessage *message, gpoin
     default:
       /* unhandled message */
         break;
-    }          
+    }
     return TRUE;
 }
 

--- a/renderers/x_display_fix.h
+++ b/renderers/x_display_fix.h
@@ -66,7 +66,6 @@ Window enum_windows(const char * str, Display * display, Window window, int dept
 
 // Fullscreen mod
 
-
 void set_fullscreen(Display* dpy, Window win, const char * name, bool* fullscreen)
 {
     // *fullscreen = !(*fullscreen);    
@@ -100,7 +99,7 @@ void fix_x_window_name(X11_Window_t * X11, const char * name) {
         Atom UTF8_STRING = XInternAtom(X11->display, "UTF8_STRING", 0);
         XChangeProperty(X11->display, X11->window, _NET_WM_NAME, UTF8_STRING, 
                         8, 0, (const unsigned char *) name, strlen(name));
-        XSync(X11->display, False);       
+        XSync(X11->display, False);
     }
 }
 

--- a/renderers/x_display_fix.h
+++ b/renderers/x_display_fix.h
@@ -64,6 +64,34 @@ Window enum_windows(const char * str, Display * display, Window window, int dept
     return (Window) NULL;
 }
 
+// Fullscreen mod
+
+
+void set_fullscreen(Display* dpy, Window win, const char * name, bool* fullscreen)
+{
+    // *fullscreen = !(*fullscreen);    
+    XClientMessageEvent msg = {
+        .type = ClientMessage,
+        .display = dpy,
+        .window = win,
+        .message_type = XInternAtom(dpy, "_NET_WM_STATE", True),
+        .format = 32,
+        .data = { .l = {
+                *fullscreen,
+                XInternAtom(dpy, "_NET_WM_STATE_FULLSCREEN", True),
+                None,
+                0,
+                1
+            }}
+    };
+    Window root = XDefaultRootWindow(dpy);     
+    win  = enum_windows(name, dpy, root, 0);
+    if (win) {
+        XSendEvent(dpy, XRootWindow(dpy, XDefaultScreen(dpy)), False, SubstructureRedirectMask | SubstructureNotifyMask, (XEvent*) &msg);
+        XSync(dpy, False);
+    }
+}
+
 void fix_x_window_name(X11_Window_t * X11, const char * name) {
     Window root = XDefaultRootWindow(X11->display);     
     X11->window  = enum_windows(name, X11->display, root, 0);
@@ -72,7 +100,7 @@ void fix_x_window_name(X11_Window_t * X11, const char * name) {
         Atom UTF8_STRING = XInternAtom(X11->display, "UTF8_STRING", 0);
         XChangeProperty(X11->display, X11->window, _NET_WM_NAME, UTF8_STRING, 
                         8, 0, (const unsigned char *) name, strlen(name));
-        XSync(X11->display, False);
+        XSync(X11->display, False);       
     }
 }
 


### PR DESCRIPTION
I added a function to toggle into fullscreen mode with F11 (during the stream). Developped on Ubuntu 20.04 (I couldn't test it on win and osx). I used the x_display_fix.h so to activate this function you have to compile with the -DZOOMFIX=ON.

Maybe need to be tested on OSX and Win and to be improved. I'm available to improve it if needed