### PR TITLE
x_display_fix.h: avoid default X11 error handling when enum_windows is called 

### DIFF
--- a/renderers/x_display_fix.h
+++ b/renderers/x_display_fix.h
@@ -49,13 +49,13 @@ Window enum_windows(const char * str, Display * display, Window window, int dept
     int i;
     XTextProperty text;
     XGetWMName(display, window, &text);
-    char* name;
+    char* name = NULL;
     XFetchName(display, window, &name);
     if (name != 0 &&  strcmp(str, name) == 0) {
         return window;
     }
     Window _root, parent;
-    Window* children;
+    Window* children = NULL;
     unsigned int n;
     XQueryTree(display, window, &_root, &parent, &children, &n);
     if (children != NULL) {


### PR DESCRIPTION
fixes #213 , provided by @march1993