### PR TITLE
use gst_macos fix for "Official" GStreamer >= 1.22 packages

### DIFF
--- a/README.html
+++ b/README.html
@@ -652,15 +652,11 @@ should <strong>not</strong> install (or should uninstall) the GStreamer
 supplied by their package manager, if they use the “official”
 release.</p>
 <ul>
-<li><strong>ADDED 2023-01-25: in the current 1.22.x releases something
-in the GStreamer macOS binaries appears to not be working (UxPlay starts
-receiving the AirPlay stream, but the video window does not
-open)</strong>. If you have this problem, use the older GStreamer-1.20.7
-binary packages until a fix is found. <em>You could instead compile the
-“official” GStreamer-1.22.x release from source: GStreamer-1.22.0 has
-been successfully built this way on a system using MacPorts: see</em> <a
-href="https://github.com/FDH2/UxPlay/wiki/Building-GStreamer-from-Source-on-macOS-with-MacPorts">the
-UxPlay Wiki</a>.</li>
+<li><strong>ADDED 2023-09-25</strong> An issue that previously prevented
+UxPlay from using the “Official” (gstreamer.freedesktop.org)
+GStreamer-1.22.x binaries has now been fixed by using a “gst_macos_main”
+API wrapper (introduced in GStreamer-1.22) when these versions of
+GStreamer are detected.</li>
 </ul>
 <p><strong>Using Homebrew’s GStreamer</strong>: pkg-config is needed:
 (“brew install pkg-config gstreamer”). This causes a large number of
@@ -707,23 +703,30 @@ when the window width is changed by dragging its side; the option “-vs
 osxvideosink force-aspect-ratio=true” can be used to make the window
 have the correct aspect ratio when it first opens.</p></li>
 </ul>
-<p><strong><em>Using GStreamer installed from MacPorts (not
-recommended):</em></strong></p>
-<p>To install: “sudo port install pkgconf”; “sudo port install
-gstreamer1-gst-plugins-base gstreamer1-gst-plugins-good
-gstreamer1-gst-plugins-bad gstreamer1-gst-libav”. <strong>The MacPorts
-GStreamer is old (v1.16.2) and built to use X11</strong>: use the
-special CMake option <code>-DUSE_X11=ON</code> when building UxPlay.
-Then uxplay must be run from an XQuartz terminal, and needs option “-vs
-ximagesink”. On a unibody (non-retina) MacBook Pro, the default
-resolution wxh = 1920x1080 was too large, but using option “-s 800x600”
-worked. The MacPorts GStreamer pipeline seems fragile against attempts
-to change the X11 window size, or to rotations that switch a connected
-client between portrait and landscape mode while uxplay is running.
-Using the MacPorts X11 GStreamer seems only possible if the image size
-is left unchanged from the initial “-s wxh” setting (also use the
-iPad/iPhone setting that locks the screen orientation against switching
-between portrait and landscape mode as the device is rotated).</p>
+<p><strong><em>Using GStreamer installed from MacPorts</em></strong></p>
+<ul>
+<li><p>(not recommended, as the MacPorts GStreamer is old (v1.16.2),
+unmaintained and built to use X11**:</p></li>
+<li><p>Instead <a
+href="https://github.com/FDH2/UxPlay/wiki/Building-GStreamer-from-Source-on-macOS-with-MacPorts">build
+gstreamer yourself</a> if you do not want to use the “Official”
+Gstreamer binaries with MacPorts.</p></li>
+</ul>
+<p>** To install MacPorts GStreamer-1.62: “sudo port install pkgconf”;
+“sudo port install gstreamer1-gst-plugins-base
+gstreamer1-gst-plugins-good gstreamer1-gst-plugins-bad
+gstreamer1-gst-libav”. Use the special CMake option
+<code>-DUSE_X11=ON</code> when building UxPlay with it: uxplay must then
+be run from an XQuartz terminal, and needs option “-vs ximagesink”. On a
+unibody (non-retina) MacBook Pro, the default resolution wxh = 1920x1080
+was too large, but using option “-s 800x600” worked. The MacPorts
+GStreamer pipeline seems fragile against attempts to change the X11
+window size, or to rotations that switch a connected client between
+portrait and landscape mode while uxplay is running. Using the MacPorts
+X11 GStreamer seems only possible if the image size is left unchanged
+from the initial “-s wxh” setting (also use the iPad/iPhone setting that
+locks the screen orientation against switching between portrait and
+landscape mode as the device is rotated).</p>
 <h2
 id="building-uxplay-on-microsoft-windows-using-msys2-with-the-mingw-64-compiler.">Building
 UxPlay on Microsoft Windows, using MSYS2 with the MinGW-64

--- a/README.md
+++ b/README.md
@@ -518,11 +518,8 @@ so you don't have to install one.) Install both the gstreamer-1.0 and gstreamer-
 to install (they install to /Library/FrameWorks/GStreamer.framework).   Homebrew or MacPorts users should **not** install (or should uninstall)
 the GStreamer supplied by their package manager, if they use the "official" release.
 
-* **ADDED 2023-01-25: in the current 1.22.x releases  something in the GStreamer macOS binaries appears to not be
-working (UxPlay starts receiving the AirPlay stream, but the video window does not open)**.  If
-you have this problem, use the older GStreamer-1.20.7 binary packages until a fix is found.  _You could instead
-compile the "official" GStreamer-1.22.x release from source: GStreamer-1.22.0 has been successfully
-built this way on a system using MacPorts: see_ [the UxPlay Wiki](https://github.com/FDH2/UxPlay/wiki/Building-GStreamer-from-Source-on-macOS-with-MacPorts).
+* **ADDED 2023-09-25** An issue that previously prevented UxPlay from using the "Official" (gstreamer.freedesktop.org) GStreamer-1.22.x binaries has now
+been fixed by using a "gst_macos_main" API wrapper (introduced in GStreamer-1.22) when these versions of GStreamer are detected.  
 
 **Using Homebrew's GStreamer**:  pkg-config is needed:  ("brew install pkg-config gstreamer").
 This causes a large number of extra packages to be installed by Homebrew as dependencies.
@@ -559,14 +556,24 @@ Finally, build and install uxplay: open a terminal and change into the UxPlay so
      correct aspect ratio when it first opens.
 
 
-***Using GStreamer installed from MacPorts (not recommended):***
+***Using GStreamer installed from MacPorts***
 
-To install: "sudo port install pkgconf"; "sudo port install gstreamer1-gst-plugins-base gstreamer1-gst-plugins-good gstreamer1-gst-plugins-bad gstreamer1-gst-libav".
-**The MacPorts GStreamer is old (v1.16.2) and built to use X11**: use the special CMake option `-DUSE_X11=ON`
-when building UxPlay. Then uxplay must be run from an XQuartz terminal, and needs
+  * (not recommended, as the MacPorts GStreamer is old (v1.16.2), unmaintained and built to use X11**:
+
+ * Instead [build gstreamer yourself](https://github.com/FDH2/UxPlay/wiki/Building-GStreamer-from-Source-on-macOS-with-MacPorts) if
+ you do not want to use the "Official" Gstreamer binaries with MacPorts.
+
+**
+To install MacPorts GStreamer-1.62: "sudo port install pkgconf";
+"sudo port install gstreamer1-gst-plugins-base gstreamer1-gst-plugins-good gstreamer1-gst-plugins-bad gstreamer1-gst-libav".
+Use the special CMake option `-DUSE_X11=ON`
+when building UxPlay with it: uxplay must then be run from an XQuartz terminal, and needs
 option "-vs ximagesink".  On a unibody (non-retina)  MacBook Pro, the default resolution  wxh = 1920x1080
 was too large, but using option "-s 800x600" worked.  The MacPorts GStreamer pipeline
-seems fragile against attempts to change the X11 window size, or to rotations that switch a connected client between portrait and landscape mode while uxplay is running. Using the MacPorts X11 GStreamer seems only possible if the image size is left unchanged from the initial "-s wxh" setting (also use the iPad/iPhone setting that locks the screen orientation against switching  between portrait and landscape mode as the device is rotated).
+seems fragile against attempts to change the X11 window size, or to rotations that switch a connected client between
+portrait and landscape mode while uxplay is running. Using the MacPorts X11 GStreamer seems only possible if the image size
+is left unchanged from the initial "-s wxh" setting (also use the iPad/iPhone setting that locks the screen orientation against
+switching  between portrait and landscape mode as the device is rotated).
 
 ## Building UxPlay on Microsoft Windows, using MSYS2 with the MinGW-64 compiler.
 

--- a/README.txt
+++ b/README.txt
@@ -645,15 +645,11 @@ Shift-Click on them to install (they install to
 should **not** install (or should uninstall) the GStreamer supplied by
 their package manager, if they use the "official" release.
 
--   **ADDED 2023-01-25: in the current 1.22.x releases something in the
-    GStreamer macOS binaries appears to not be working (UxPlay starts
-    receiving the AirPlay stream, but the video window does not open)**.
-    If you have this problem, use the older GStreamer-1.20.7 binary
-    packages until a fix is found. *You could instead compile the
-    "official" GStreamer-1.22.x release from source: GStreamer-1.22.0
-    has been successfully built this way on a system using MacPorts:
-    see* [the UxPlay
-    Wiki](https://github.com/FDH2/UxPlay/wiki/Building-GStreamer-from-Source-on-macOS-with-MacPorts).
+-   **ADDED 2023-09-25** An issue that previously prevented UxPlay from
+    using the "Official" (gstreamer.freedesktop.org) GStreamer-1.22.x
+    binaries has now been fixed by using a "gst_macos_main" API wrapper
+    (introduced in GStreamer-1.22) when these versions of GStreamer are
+    detected.
 
 **Using Homebrew's GStreamer**: pkg-config is needed: ("brew install
 pkg-config gstreamer"). This causes a large number of extra packages to
@@ -703,23 +699,31 @@ make install" (same as for Linux).
     option "-vs osxvideosink force-aspect-ratio=true" can be used to
     make the window have the correct aspect ratio when it first opens.
 
-***Using GStreamer installed from MacPorts (not recommended):***
+***Using GStreamer installed from MacPorts***
 
-To install: "sudo port install pkgconf"; "sudo port install
-gstreamer1-gst-plugins-base gstreamer1-gst-plugins-good
-gstreamer1-gst-plugins-bad gstreamer1-gst-libav". **The MacPorts
-GStreamer is old (v1.16.2) and built to use X11**: use the special CMake
-option `-DUSE_X11=ON` when building UxPlay. Then uxplay must be run from
-an XQuartz terminal, and needs option "-vs ximagesink". On a unibody
-(non-retina) MacBook Pro, the default resolution wxh = 1920x1080 was too
-large, but using option "-s 800x600" worked. The MacPorts GStreamer
-pipeline seems fragile against attempts to change the X11 window size,
-or to rotations that switch a connected client between portrait and
-landscape mode while uxplay is running. Using the MacPorts X11 GStreamer
-seems only possible if the image size is left unchanged from the initial
-"-s wxh" setting (also use the iPad/iPhone setting that locks the screen
-orientation against switching between portrait and landscape mode as the
-device is rotated).
+-   (not recommended, as the MacPorts GStreamer is old (v1.16.2),
+    unmaintained and built to use X11\*\*:
+
+-   Instead [build gstreamer
+    yourself](https://github.com/FDH2/UxPlay/wiki/Building-GStreamer-from-Source-on-macOS-with-MacPorts)
+    if you do not want to use the "Official" Gstreamer binaries with
+    MacPorts.
+
+\*\* To install MacPorts GStreamer-1.62: "sudo port install pkgconf";
+"sudo port install gstreamer1-gst-plugins-base
+gstreamer1-gst-plugins-good gstreamer1-gst-plugins-bad
+gstreamer1-gst-libav". Use the special CMake option `-DUSE_X11=ON` when
+building UxPlay with it: uxplay must then be run from an XQuartz
+terminal, and needs option "-vs ximagesink". On a unibody (non-retina)
+MacBook Pro, the default resolution wxh = 1920x1080 was too large, but
+using option "-s 800x600" worked. The MacPorts GStreamer pipeline seems
+fragile against attempts to change the X11 window size, or to rotations
+that switch a connected client between portrait and landscape mode while
+uxplay is running. Using the MacPorts X11 GStreamer seems only possible
+if the image size is left unchanged from the initial "-s wxh" setting
+(also use the iPad/iPhone setting that locks the screen orientation
+against switching between portrait and landscape mode as the device is
+rotated).
 
 ## Building UxPlay on Microsoft Windows, using MSYS2 with the MinGW-64 compiler.
 

--- a/renderers/CMakeLists.txt
+++ b/renderers/CMakeLists.txt
@@ -44,6 +44,12 @@ target_link_libraries ( renderers PUBLIC airplay )
 if( GST_INCLUDE_DIRS MATCHES "/Library/FrameWorks/GStreamer.framework/include" )
   set( GST_INCLUDE_DIRS "/Library/FrameWorks/GStreamer.framework/Headers")
   message( STATUS  "GST_INCLUDE_DIRS" ${GST_INCLUDE_DIRS} )
+# fix to use -DGST_MACOS for "Official" GStreamer >= 1.22 packages
+  pkg_check_modules ( GST122 gstreamer-1.0>=1.22 )
+  if ( GST122_FOUND )
+     add_definitions (-DGST_MACOS )
+     message ( STATUS "Use -DGST_MACOS" )
+  endif()
 endif()
 target_include_directories ( renderers PUBLIC ${GST_INCLUDE_DIRS} )
 
@@ -60,5 +66,6 @@ elseif( CMAKE_VERSION VERSION_LESS "3.12" )
 else()		  
   target_link_libraries( renderers PUBLIC ${GST_LINK_LIBRARIES} )
 endif()
+
 
 

--- a/uxplay.cpp
+++ b/uxplay.cpp
@@ -1505,8 +1505,20 @@ static void read_config_file(const char * filename, const char * uxplay_name) {
         free (argv);
     }
 }
+#ifdef GST_MACOS
+/* workaround for GStreamer >= 1.22 "Official Builds" on macOS */
+#include <TargetConditionals.h>
+#include <gst/gstmacos.h>
+int real_main (int argc, char *argv[]);
 
 int main (int argc, char *argv[]) {
+  return  gst_macos_main ((GstMainFunc) real_main, argc, argv , NULL);
+}
+
+int real_main (int argc, char *argv[]) {
+#else
+int main (int argc, char *argv[]) {
+#endif
     std::vector<char> server_hw_addr;
     std::string mac_address;
     std::string config_file = "";


### PR DESCRIPTION
Allows use of GStreamer-1.22.x macOS binaries from https://gstreamer.freedesktop.org/