### PR TITLE
Add Development Casting Support to UxPlay

### DIFF
--- a/lib/casting.c
+++ b/lib/casting.c
@@ -3,6 +3,9 @@ GenghisKhanDrip*/
 
 #include "casting.h"
 #include <regex.h>
+#include <stdio.h>
+#include "utils.h"
+#include <plist/plist.h>
 
 bool isHLSUrl(char* url) {
     regex_t checkHTTP;
@@ -16,7 +19,7 @@ bool isHLSUrl(char* url) {
     result = regexec(&checkHTTP, url, 0, NULL, 0);
 
     if (result == 0) {
-        result = regexec(&checkHTTP, url, 0, NULL, 0);
+        result = regexec(&checkM3U8, url, 0, NULL, 0);
         if (result == 0) {
             return true;
         } else if (result == REG_NOMATCH) {
@@ -35,31 +38,62 @@ bool isHLSUrl(char* url) {
 void startHLSRequests(hls_cast_t *cast)
 {
 
-    regex_t checkHTTP;
-    regex_t checkM3U8;
-    regmatch_t matches[2];
+    const char* found = strstr(cast->playback_location, "://");
 
-    int result;
-    result = regcomp(&checkHTTP, "^(https?://)", REG_EXTENDED);
-    result = regcomp(&checkM3U8, "\\.m3u8$", REG_EXTENDED);
-    //TODO: Handle Errors
-    
-    result = regexec(&checkHTTP, cast->playback_location, 2, matches, 0);
+    if (found) {
+        // Calculate the length up to the delimiter
+        size_t length = found - cast->playback_location;
 
-    if (result == 0) {
-        result = regexec(&checkHTTP, cast->playback_location, 0, NULL, 0);
-        if (result == 0) {
-            return;
-        } else if (result == REG_NOMATCH) {
-            return;
-        } else {
-            return;
-        }
-    } else if (result == REG_NOMATCH) {
-        return;
+        // Extract the substring
+        char protocol[length];
+        strncpy(protocol, cast->playback_location, length);
+
+        printf("Result: %s\n", protocol);
+
+        char* hostname1 = "localhost:";
+        char* hostname = malloc(strlen(hostname1) + strlen(cast->port));
+        strcpy(hostname, hostname1);
+        concatenate_string(hostname, cast->port);
+        str_replace(cast->playback_location, protocol, "http");
+        str_replace(cast->playback_location, "127.0.0.1", hostname);
+        str_replace(cast->playback_location, "localhost", hostname);
+        printf("String is %s\n", cast->playback_location);
+
+        plist_t fcup_req = plist_new_dict();
+
+        plist_t session = plist_new_uint(1);
+        plist_dict_set_item(fcup_req, "sessionID", session);
+
+        plist_t type = plist_new_string("unhandledURLRequest");
+        plist_dict_set_item(fcup_req, "type", type);
+
+        plist_t fcup_data = plist_new_dict();
+        plist_t clientinfo = plist_new_uint(1);
+        plist_dict_set_item(fcup_data, "FCUP_Response_ClientInfo", clientinfo);
+        plist_t clientref = plist_new_uint(40030004);
+        plist_dict_set_item(fcup_data, "FCUP_Response_ClientRef", clientref);
+        plist_t reqid = plist_new_uint(cast->requestid++);
+        plist_dict_set_item(fcup_data, "FCUP_Response_RequestID", reqid);
+        plist_t url = plist_new_string(cast->playback_location);
+        plist_dict_set_item(fcup_data, "FCUP_Response_URL", url);
+
+        plist_t plheaders = plist_new_dict();
+        plist_t plsessionid = plist_new_string(cast->cast_session);
+        plist_dict_set_item(plheaders, "X-Playback-Session-Id", plsessionid);
+        plist_t agent = plist_new_string("AppleCoreMedia/1.0.0.11B554a (Apple TV; U; CPU OS 7_0_4 like Mac OS X; en_us)");
+        plist_dict_set_item(plheaders, "User-Agent", agent);
+
+        plist_dict_set_item(fcup_data, "FCUP_Response_Headers", plheaders);
+        plist_dict_set_item(fcup_req, "request", fcup_data);
+
+        char *xml = NULL;
+        uint32_t plength = 0;
+        plist_to_xml(fcup_req, &xml, &plength);
+        plength--;
+        printf("%s", xml);
+        plist_free(fcup_req);
     } else {
-        //TODO: Handle Errors
-        return;
+        printf("Delimiter not found in the input.\n");
     }
 
 }

--- a/lib/casting.c
+++ b/lib/casting.c
@@ -1,0 +1,65 @@
+/* File that Handles Information about Casting
+GenghisKhanDrip*/
+
+#include "casting.h"
+#include <regex.h>
+
+bool isHLSUrl(char* url) {
+    regex_t checkHTTP;
+    regex_t checkM3U8;
+
+    int result;
+    result = regcomp(&checkHTTP, "^(https?://)", REG_EXTENDED);
+    result = regcomp(&checkM3U8, "\\.m3u8$", REG_EXTENDED);
+    //TODO: Handle Errors
+    
+    result = regexec(&checkHTTP, url, 0, NULL, 0);
+
+    if (result == 0) {
+        result = regexec(&checkHTTP, url, 0, NULL, 0);
+        if (result == 0) {
+            return true;
+        } else if (result == REG_NOMATCH) {
+            return false;
+        } else {
+            return false;
+        }
+    } else if (result == REG_NOMATCH) {
+        return true;
+    } else {
+        //TODO: Handle Errors
+        return false;
+    }
+}
+
+void startHLSRequests(hls_cast_t *cast)
+{
+
+    regex_t checkHTTP;
+    regex_t checkM3U8;
+    regmatch_t matches[2];
+
+    int result;
+    result = regcomp(&checkHTTP, "^(https?://)", REG_EXTENDED);
+    result = regcomp(&checkM3U8, "\\.m3u8$", REG_EXTENDED);
+    //TODO: Handle Errors
+    
+    result = regexec(&checkHTTP, cast->playback_location, 2, matches, 0);
+
+    if (result == 0) {
+        result = regexec(&checkHTTP, cast->playback_location, 0, NULL, 0);
+        if (result == 0) {
+            return;
+        } else if (result == REG_NOMATCH) {
+            return;
+        } else {
+            return;
+        }
+    } else if (result == REG_NOMATCH) {
+        return;
+    } else {
+        //TODO: Handle Errors
+        return;
+    }
+
+}

--- a/lib/casting.h
+++ b/lib/casting.h
@@ -9,8 +9,10 @@
 #include <stddef.h>
 
 struct hls_cast_s {
-    const char *cast_session;
+    char* port;
+    char *cast_session;
     int castsessionlen;
+    int requestid;
 
     char* playback_uuid;
     char* playback_location;

--- a/lib/casting.h
+++ b/lib/casting.h
@@ -1,0 +1,23 @@
+/* File that handles information regarding casting data
+ GenghisKhanDrip*/
+
+#ifndef CASTING
+#define CASTING
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+
+struct hls_cast_s {
+    const char *cast_session;
+    int castsessionlen;
+
+    char* playback_uuid;
+    char* playback_location;
+};
+typedef struct hls_cast_s hls_cast_t;
+
+bool isHLSUrl(char* url);
+void startHLSRequests(hls_cast_t* cast);
+
+#endif

--- a/lib/dnssd.c
+++ b/lib/dnssd.c
@@ -353,7 +353,7 @@ dnssd_register_airplay(dnssd_t *dnssd, unsigned short port)
 
     assert(dnssd);
 
-    snprintf(features, sizeof(features), "0x%X,0x%X", dnssd->features1, dnssd->features2);
+    snprintf(features, sizeof(features), "0x%X", dnssd->features1);
 
     /* Convert hardware address to string */
     if (utils_hwaddr_airplay(device_id, sizeof(device_id), dnssd->hw_addr, dnssd->hw_addr_len) < 0) {

--- a/lib/dnssd.c
+++ b/lib/dnssd.c
@@ -293,25 +293,25 @@ dnssd_register_raop(dnssd_t *dnssd, unsigned short port)
     snprintf(features, sizeof(features), "0x%X,0x%X", dnssd->features1, dnssd->features2);
 
     dnssd->TXTRecordCreate(&dnssd->raop_record, 0, NULL);
-    dnssd->TXTRecordSetValue(&dnssd->raop_record, "ch", strlen(RAOP_CH), RAOP_CH);
+    //dnssd->TXTRecordSetValue(&dnssd->raop_record, "ch", strlen(RAOP_CH), RAOP_CH);
     dnssd->TXTRecordSetValue(&dnssd->raop_record, "cn", strlen(RAOP_CN), RAOP_CN);
     dnssd->TXTRecordSetValue(&dnssd->raop_record, "da", strlen(RAOP_DA), RAOP_DA);
     dnssd->TXTRecordSetValue(&dnssd->raop_record, "et", strlen(RAOP_ET), RAOP_ET);
     dnssd->TXTRecordSetValue(&dnssd->raop_record, "vv", strlen(RAOP_VV), RAOP_VV);
     dnssd->TXTRecordSetValue(&dnssd->raop_record, "ft", strlen(features), features);
     dnssd->TXTRecordSetValue(&dnssd->raop_record, "am", strlen(GLOBAL_MODEL), GLOBAL_MODEL);
-    dnssd->TXTRecordSetValue(&dnssd->raop_record, "md", strlen(RAOP_MD), RAOP_MD);
-    dnssd->TXTRecordSetValue(&dnssd->raop_record, "rhd", strlen(RAOP_RHD), RAOP_RHD);
-    if (dnssd->require_pw) {
+    //dnssd->TXTRecordSetValue(&dnssd->raop_record, "md", strlen(RAOP_MD), RAOP_MD);
+    //dnssd->TXTRecordSetValue(&dnssd->raop_record, "rhd", strlen(RAOP_RHD), RAOP_RHD);
+    /*if (dnssd->require_pw) {
         dnssd->TXTRecordSetValue(&dnssd->raop_record, "pw", strlen("true"), "true");
     } else {
         dnssd->TXTRecordSetValue(&dnssd->raop_record, "pw", strlen("false"), "false");
-    }
-    dnssd->TXTRecordSetValue(&dnssd->raop_record, "sr", strlen(RAOP_SR), RAOP_SR);
-    dnssd->TXTRecordSetValue(&dnssd->raop_record, "ss", strlen(RAOP_SS), RAOP_SS);
-    dnssd->TXTRecordSetValue(&dnssd->raop_record, "sv", strlen(RAOP_SV), RAOP_SV);
+    }*/
+    //dnssd->TXTRecordSetValue(&dnssd->raop_record, "sr", strlen(RAOP_SR), RAOP_SR);
+    //dnssd->TXTRecordSetValue(&dnssd->raop_record, "ss", strlen(RAOP_SS), RAOP_SS);
+    //dnssd->TXTRecordSetValue(&dnssd->raop_record, "sv", strlen(RAOP_SV), RAOP_SV);
     dnssd->TXTRecordSetValue(&dnssd->raop_record, "tp", strlen(RAOP_TP), RAOP_TP);
-    dnssd->TXTRecordSetValue(&dnssd->raop_record, "txtvers", strlen(RAOP_TXTVERS), RAOP_TXTVERS);
+    //dnssd->TXTRecordSetValue(&dnssd->raop_record, "txtvers", strlen(RAOP_TXTVERS), RAOP_TXTVERS);
     dnssd->TXTRecordSetValue(&dnssd->raop_record, "sf", strlen(RAOP_SF), RAOP_SF);
     dnssd->TXTRecordSetValue(&dnssd->raop_record, "vs", strlen(RAOP_VS), RAOP_VS);
     dnssd->TXTRecordSetValue(&dnssd->raop_record, "vn", strlen(RAOP_VN), RAOP_VN);
@@ -368,11 +368,11 @@ dnssd_register_airplay(dnssd_t *dnssd, unsigned short port)
     dnssd->TXTRecordSetValue(&dnssd->airplay_record, "flags", strlen(AIRPLAY_FLAGS), AIRPLAY_FLAGS);
     dnssd->TXTRecordSetValue(&dnssd->airplay_record, "model", strlen(GLOBAL_MODEL), GLOBAL_MODEL);
     dnssd->TXTRecordSetValue(&dnssd->airplay_record, "pk", strlen(dnssd->pk), dnssd->pk);
-    if (dnssd->require_pw) {
+    /*if (dnssd->require_pw) {
         dnssd->TXTRecordSetValue(&dnssd->airplay_record, "pw", strlen("true"), "true");
     } else {
         dnssd->TXTRecordSetValue(&dnssd->airplay_record, "pw", strlen("false"), "false");
-    }	  
+    }*/	  
     dnssd->TXTRecordSetValue(&dnssd->airplay_record, "pi", strlen(AIRPLAY_PI), AIRPLAY_PI);
     dnssd->TXTRecordSetValue(&dnssd->airplay_record, "srcvers", strlen(AIRPLAY_SRCVERS), AIRPLAY_SRCVERS);
     dnssd->TXTRecordSetValue(&dnssd->airplay_record, "vv", strlen(AIRPLAY_VV), AIRPLAY_VV);

--- a/lib/dnssd.c
+++ b/lib/dnssd.c
@@ -293,25 +293,25 @@ dnssd_register_raop(dnssd_t *dnssd, unsigned short port)
     snprintf(features, sizeof(features), "0x%X,0x%X", dnssd->features1, dnssd->features2);
 
     dnssd->TXTRecordCreate(&dnssd->raop_record, 0, NULL);
-    //dnssd->TXTRecordSetValue(&dnssd->raop_record, "ch", strlen(RAOP_CH), RAOP_CH);
+    dnssd->TXTRecordSetValue(&dnssd->raop_record, "ch", strlen(RAOP_CH), RAOP_CH);
     dnssd->TXTRecordSetValue(&dnssd->raop_record, "cn", strlen(RAOP_CN), RAOP_CN);
     dnssd->TXTRecordSetValue(&dnssd->raop_record, "da", strlen(RAOP_DA), RAOP_DA);
     dnssd->TXTRecordSetValue(&dnssd->raop_record, "et", strlen(RAOP_ET), RAOP_ET);
     dnssd->TXTRecordSetValue(&dnssd->raop_record, "vv", strlen(RAOP_VV), RAOP_VV);
     dnssd->TXTRecordSetValue(&dnssd->raop_record, "ft", strlen(features), features);
     dnssd->TXTRecordSetValue(&dnssd->raop_record, "am", strlen(GLOBAL_MODEL), GLOBAL_MODEL);
-    //dnssd->TXTRecordSetValue(&dnssd->raop_record, "md", strlen(RAOP_MD), RAOP_MD);
-    //dnssd->TXTRecordSetValue(&dnssd->raop_record, "rhd", strlen(RAOP_RHD), RAOP_RHD);
-    /*if (dnssd->require_pw) {
+    dnssd->TXTRecordSetValue(&dnssd->raop_record, "md", strlen(RAOP_MD), RAOP_MD);
+    dnssd->TXTRecordSetValue(&dnssd->raop_record, "rhd", strlen(RAOP_RHD), RAOP_RHD);
+    if (dnssd->require_pw) {
         dnssd->TXTRecordSetValue(&dnssd->raop_record, "pw", strlen("true"), "true");
     } else {
         dnssd->TXTRecordSetValue(&dnssd->raop_record, "pw", strlen("false"), "false");
-    }*/
-    //dnssd->TXTRecordSetValue(&dnssd->raop_record, "sr", strlen(RAOP_SR), RAOP_SR);
-    //dnssd->TXTRecordSetValue(&dnssd->raop_record, "ss", strlen(RAOP_SS), RAOP_SS);
-    //dnssd->TXTRecordSetValue(&dnssd->raop_record, "sv", strlen(RAOP_SV), RAOP_SV);
+    }
+    dnssd->TXTRecordSetValue(&dnssd->raop_record, "sr", strlen(RAOP_SR), RAOP_SR);
+    dnssd->TXTRecordSetValue(&dnssd->raop_record, "ss", strlen(RAOP_SS), RAOP_SS);
+    dnssd->TXTRecordSetValue(&dnssd->raop_record, "sv", strlen(RAOP_SV), RAOP_SV);
     dnssd->TXTRecordSetValue(&dnssd->raop_record, "tp", strlen(RAOP_TP), RAOP_TP);
-    //dnssd->TXTRecordSetValue(&dnssd->raop_record, "txtvers", strlen(RAOP_TXTVERS), RAOP_TXTVERS);
+    dnssd->TXTRecordSetValue(&dnssd->raop_record, "txtvers", strlen(RAOP_TXTVERS), RAOP_TXTVERS);
     dnssd->TXTRecordSetValue(&dnssd->raop_record, "sf", strlen(RAOP_SF), RAOP_SF);
     dnssd->TXTRecordSetValue(&dnssd->raop_record, "vs", strlen(RAOP_VS), RAOP_VS);
     dnssd->TXTRecordSetValue(&dnssd->raop_record, "vn", strlen(RAOP_VN), RAOP_VN);
@@ -368,11 +368,11 @@ dnssd_register_airplay(dnssd_t *dnssd, unsigned short port)
     dnssd->TXTRecordSetValue(&dnssd->airplay_record, "flags", strlen(AIRPLAY_FLAGS), AIRPLAY_FLAGS);
     dnssd->TXTRecordSetValue(&dnssd->airplay_record, "model", strlen(GLOBAL_MODEL), GLOBAL_MODEL);
     dnssd->TXTRecordSetValue(&dnssd->airplay_record, "pk", strlen(dnssd->pk), dnssd->pk);
-    /*if (dnssd->require_pw) {
+    if (dnssd->require_pw) {
         dnssd->TXTRecordSetValue(&dnssd->airplay_record, "pw", strlen("true"), "true");
     } else {
         dnssd->TXTRecordSetValue(&dnssd->airplay_record, "pw", strlen("false"), "false");
-    }*/	  
+    }  
     dnssd->TXTRecordSetValue(&dnssd->airplay_record, "pi", strlen(AIRPLAY_PI), AIRPLAY_PI);
     dnssd->TXTRecordSetValue(&dnssd->airplay_record, "srcvers", strlen(AIRPLAY_SRCVERS), AIRPLAY_SRCVERS);
     dnssd->TXTRecordSetValue(&dnssd->airplay_record, "vv", strlen(AIRPLAY_VV), AIRPLAY_VV);

--- a/lib/dnssdint.h
+++ b/lib/dnssdint.h
@@ -22,7 +22,7 @@
 
 /* the previous behavior of announcing UxPlay with a fixed public key PK
  * can be restored by uncommenting the following line  */
-//#define PK "b07727d6f6cd6e08b58ede525ec3cdeaa252ad9f683feb212ef8a205246554e7"
+#define PK "99FD4299889422515FBD27949E4E1E21B2AF50A454499E3D4BE75A4E0F55FE63"
 
 #define RAOP_TXTVERS "1"
 #define RAOP_CH "2"             /* Audio channels: 2 */

--- a/lib/dnssdint.h
+++ b/lib/dnssdint.h
@@ -29,8 +29,8 @@
 #define RAOP_CN "0,1,2,3"       /* Audio codec: PCM, ALAC, AAC, AAC ELD */
 #define RAOP_ET "0,3,5"         /* Encryption type: None, FairPlay, FairPlay SAPv2.5 */
 #define RAOP_VV "2"
-#define FEATURES_1 "0x5A7FFEE6" /* first 32 bits of features, with bit 27 ("supports legacy pairing") ON */
-//#define FEATURES_1 "0x527FFEE6" /* first 32 bits of features, with bit 27 ("supports legacy pairing") OFF */
+//#define FEATURES_1 "0x5A7FFEE6" /* first 32 bits of features, with bit 27 ("supports legacy pairing") ON */
+#define FEATURES_1 "0x527FFFF7" /* first 32 bits of features, with bit 27 ("supports legacy pairing") OFF */
 #define FEATURES_2  "0x0"        /* second 32 bits of features */
 #define RAOP_RHD "5.6.0.0"
 #define RAOP_SF "0x4"
@@ -46,6 +46,7 @@
 #define AIRPLAY_SRCVERS GLOBAL_VERSION /*defined in global.h */
 #define AIRPLAY_FLAGS "0x4"
 #define AIRPLAY_VV "2"
-#define AIRPLAY_PI "2e388006-13ba-4041-9a67-25dd4a43d536"
+//#define AIRPLAY_PI "2e388006-13ba-4041-9a67-25dd4a43d536"
+#define AIRPLAY_PI "b08f5a79-db29-4384-b456-a4784d9e6055"
 
 #endif

--- a/lib/dnssdint.h
+++ b/lib/dnssdint.h
@@ -22,7 +22,7 @@
 
 /* the previous behavior of announcing UxPlay with a fixed public key PK
  * can be restored by uncommenting the following line  */
-#define PK "99FD4299889422515FBD27949E4E1E21B2AF50A454499E3D4BE75A4E0F55FE63"
+//#define PK "99FD4299889422515FBD27949E4E1E21B2AF50A454499E3D4BE75A4E0F55FE63"
 
 #define RAOP_TXTVERS "1"
 #define RAOP_CH "2"             /* Audio channels: 2 */

--- a/lib/dnssdint.h
+++ b/lib/dnssdint.h
@@ -33,7 +33,7 @@
 #define FEATURES_1 "0x527FFFF7" /* first 32 bits of features, with bit 27 ("supports legacy pairing") OFF */
 #define FEATURES_2  "0x0"        /* second 32 bits of features */
 #define RAOP_RHD "5.6.0.0"
-#define RAOP_SF "0x4"
+#define RAOP_SF "0x04"
 #define RAOP_SV "false"
 #define RAOP_DA "true"
 #define RAOP_SR "44100"         /* Sample rate: 44100 */
@@ -44,7 +44,7 @@
 #define RAOP_VN "65537"
 
 #define AIRPLAY_SRCVERS GLOBAL_VERSION /*defined in global.h */
-#define AIRPLAY_FLAGS "0x4"
+#define AIRPLAY_FLAGS "0x04"
 #define AIRPLAY_VV "2"
 //#define AIRPLAY_PI "2e388006-13ba-4041-9a67-25dd4a43d536"
 #define AIRPLAY_PI "b08f5a79-db29-4384-b456-a4784d9e6055"

--- a/lib/http_request.c
+++ b/lib/http_request.c
@@ -185,6 +185,7 @@ http_request_add_data(http_request_t *request, const char *data, int datalen)
 
     ret = llhttp_execute(&request->parser,
                               data, datalen);
+    llhttp_resume_after_upgrade(&request->parser);
     return ret;
 }
 

--- a/lib/httpd.c
+++ b/lib/httpd.c
@@ -178,7 +178,8 @@ httpd_accept_connection(httpd_t *httpd, int server_fd, int is_ipv6)
 #ifdef NOHOLD
     /* remove existing connections to make way for new connections:
      * this will only occur if max_connections > 2 */
-    if (httpd->open_connections >= 2)  {
+    /* Removing this because it blocks casting connections */
+    /*if (httpd->open_connections >= 2)  {
         logger_log(httpd->logger, LOGGER_INFO, "Destroying current connections to allow connection by new client");
         for (int i = 0; i<httpd->max_connections; i++) {
             http_connection_t *connection = &httpd->connections[i];
@@ -187,7 +188,7 @@ httpd_accept_connection(httpd_t *httpd, int server_fd, int is_ipv6)
             }
 	    httpd_remove_connection(httpd, connection);
         }
-    }
+    }*/
 #endif
     
     ret = httpd_add_connection(httpd, fd, local, local_len, remote, remote_len);

--- a/lib/raop.c
+++ b/lib/raop.c
@@ -228,7 +228,7 @@ conn_request(void *ptr, http_request_t *request, http_response_t **response) {
         }
     }
 
-    if (!strcmp(url, "/server-info")) {
+    if (!strcmp(url, "/server-info") || !strcmp(url, "/play") || !strcmp(url, "/playback-info") || strstr(url, "/setProperty")) {
         *response = http_response_init("HTTP/1.1", 200, "OK");  
     } else if (!strcmp(url, "/reverse")) {
         *response = http_response_init("HTTP/1.1", 101, "Switching Protocols");
@@ -258,7 +258,7 @@ conn_request(void *ptr, http_request_t *request, http_response_t **response) {
     if (!strcmp(method, "GET") && !strcmp(url, "/info")) {
         handler = &raop_handler_info;
     } else if (!strcmp(method, "GET") && !strcmp(url, "/server-info")) {
-        handler = &raop_handler_server_info;
+        handler = &http_handler_server_info;
     } else if (!strcmp(method, "POST") && !strcmp(url, "/pair-pin-start")) {
         handler = &raop_handler_pairpinstart;
     } else if (!strcmp(method, "POST") && !strcmp(url, "/pair-setup-pin")) {
@@ -286,7 +286,9 @@ conn_request(void *ptr, http_request_t *request, http_response_t **response) {
     } else if (!strcmp(method, "TEARDOWN")) {
         handler = &raop_handler_teardown;
     } else if (!strcmp(method, "POST") && !strcmp(url, "/reverse")) {
-        handler = &raop_handler_reverse;
+        handler = &http_handler_reverse;
+    } else if (!strcmp(method, "GET") && !strcmp(url, "/playback-info")) {
+        handler = &http_handler_playback_info;
     } else {
         logger_log(conn->raop->logger, LOGGER_INFO, "Unhandled Client Request: %s %s", method, url);
     }

--- a/lib/raop.c
+++ b/lib/raop.c
@@ -227,6 +227,8 @@ conn_request(void *ptr, http_request_t *request, http_response_t **response) {
 
     if (!strcmp(url, "/server-info")) {
         *response = http_response_init("HTTP/1.1", 200, "OK");  
+    } else if (!strcmp(url, "/reverse")) {
+        *response = http_response_init("HTTP/1.1", 101, "Switching Protocols");
     } else {
         *response = http_response_init("RTSP/1.0", 200, "OK");
     }
@@ -275,8 +277,8 @@ conn_request(void *ptr, http_request_t *request, http_response_t **response) {
         handler = &raop_handler_flush;
     } else if (!strcmp(method, "TEARDOWN")) {
         handler = &raop_handler_teardown;
-    } else if (!strcmp(url, "/reverse")) {
-        logger_log(conn->raop->logger, LOGGER_DEBUG, "REVERSE TIME");
+    } else if (!strcmp(method, "POST") && !strcmp(url, "/reverse")) {
+        handler = &raop_handler_reverse;
     } else {
         logger_log(conn->raop->logger, LOGGER_INFO, "Unhandled Client Request: %s %s", method, url);
     }

--- a/lib/raop.c
+++ b/lib/raop.c
@@ -225,7 +225,11 @@ conn_request(void *ptr, http_request_t *request, http_response_t **response) {
         }
     }
 
-    *response = http_response_init("RTSP/1.0", 200, "OK");
+    if (!strcmp(url, "/server-info")) {
+        *response = http_response_init("HTTP/1.1", 200, "OK");  
+    } else {
+        *response = http_response_init("RTSP/1.0", 200, "OK");
+    }
 
     if (!strcmp(method, "RECORD")) {
         http_response_add_header(*response, "Audio-Latency", "0");
@@ -243,6 +247,8 @@ conn_request(void *ptr, http_request_t *request, http_response_t **response) {
     raop_handler_t handler = NULL;
     if (!strcmp(method, "GET") && !strcmp(url, "/info")) {
         handler = &raop_handler_info;
+    } else if (!strcmp(method, "GET") && !strcmp(url, "/server-info")) {
+        handler = &raop_handler_server_info;
     } else if (!strcmp(method, "POST") && !strcmp(url, "/pair-pin-start")) {
         handler = &raop_handler_pairpinstart;
     } else if (!strcmp(method, "POST") && !strcmp(url, "/pair-setup-pin")) {

--- a/lib/raop.c
+++ b/lib/raop.c
@@ -188,7 +188,7 @@ conn_request(void *ptr, http_request_t *request, http_response_t **response) {
         }
     }
 
-    if (!method || !cseq) {
+    if (!method) {
         return;
     }
     logger_log(conn->raop->logger, LOGGER_DEBUG, "\n%s %s RTSP/1.0", method, url);
@@ -232,7 +232,9 @@ conn_request(void *ptr, http_request_t *request, http_response_t **response) {
     } else {
         http_response_add_header(*response, "Audio-Jack-Status", "Connected; type=digital");
     }
-    http_response_add_header(*response, "CSeq", cseq);
+    if (cseq) {
+        http_response_add_header(*response, "CSeq", cseq);
+    }
     http_response_add_header(*response, "Date", gmt_time_string());
     http_response_add_header(*response, "Server", "AirTunes/"GLOBAL_VERSION);
     http_response_add_header(*response, "Session", "CAFEBABE");

--- a/lib/raop.c
+++ b/lib/raop.c
@@ -89,6 +89,9 @@ struct raop_conn_s {
     unsigned char *remote;
     int remotelen;
 
+    const char *cast_session;
+    int castsessionlen;
+
     bool have_active_remote;
 };
 typedef struct raop_conn_s raop_conn_t;
@@ -237,6 +240,11 @@ conn_request(void *ptr, http_request_t *request, http_response_t **response) {
         http_response_add_header(*response, "Audio-Latency", "0");
     } else {
         http_response_add_header(*response, "Audio-Jack-Status", "Connected; type=digital");
+    }
+    if (!strcmp(url, "/reverse")) {
+        const char *reverseconn;
+        reverseconn = http_request_get_header(request, "Connection");
+        http_response_add_header(*response, "Connection", reverseconn);
     }
     if (cseq) {
         http_response_add_header(*response, "CSeq", cseq);

--- a/lib/raop.c
+++ b/lib/raop.c
@@ -228,7 +228,7 @@ conn_request(void *ptr, http_request_t *request, http_response_t **response) {
         }
     }
 
-    if (!strcmp(url, "/server-info") || !strcmp(url, "/play") || !strcmp(url, "/playback-info") || strstr(url, "/setProperty")) {
+    if (!strcmp(url, "/server-info") || !strcmp(url, "/play") || !strcmp(url, "/playback-info") || strstr(url, "/setProperty") || strstr(url, "/rate") || strstr(url, "/getProperty")) {
         *response = http_response_init("HTTP/1.1", 200, "OK");  
     } else if (!strcmp(url, "/reverse")) {
         *response = http_response_init("HTTP/1.1", 101, "Switching Protocols");
@@ -289,6 +289,10 @@ conn_request(void *ptr, http_request_t *request, http_response_t **response) {
         handler = &http_handler_reverse;
     } else if (!strcmp(method, "GET") && !strcmp(url, "/playback-info")) {
         handler = &http_handler_playback_info;
+    } else if (strstr(url, "/setProperty")) {
+        handler = &http_handler_set_property;
+    } else if (strstr(url, "/play") || strstr(url, "/rate") || strstr(url, "/getProperty"))  {
+        http_response_add_header(*response, "Content-Length", "0");
     } else {
         logger_log(conn->raop->logger, LOGGER_INFO, "Unhandled Client Request: %s %s", method, url);
     }

--- a/lib/raop.c
+++ b/lib/raop.c
@@ -115,12 +115,16 @@ conn_init(void *opaque, unsigned char *local, int locallen, unsigned char *remot
     conn->raop_ntp = NULL;
     conn->fairplay = fairplay_init(raop->logger);
     conn->castdata = calloc(1, sizeof(hls_cast_t));
+    conn->castdata->port = malloc(sizeof(conn->raop->port)+5);
+    snprintf(conn->castdata->port, sizeof(conn->raop->port)+5, "%hu", conn->raop->port);
     conn->castdata->cast_session = NULL;
     conn->castdata->castsessionlen = 0;
+    conn->castdata->requestid = 0;
     conn->castdata->playback_uuid = NULL;
     conn->castdata->playback_location = NULL;
     if (!conn->castdata) {
-        logger_log(conn->raop->logger, LOGGER_CRIT, "Aw Hell Nah wtf bro");
+        free(conn);
+        return NULL;
     }
 
     if (!conn->fairplay) {

--- a/lib/raop.c
+++ b/lib/raop.c
@@ -275,6 +275,8 @@ conn_request(void *ptr, http_request_t *request, http_response_t **response) {
         handler = &raop_handler_flush;
     } else if (!strcmp(method, "TEARDOWN")) {
         handler = &raop_handler_teardown;
+    } else if (!strcmp(url, "/reverse")) {
+        logger_log(conn->raop->logger, LOGGER_DEBUG, "REVERSE TIME");
     } else {
         logger_log(conn->raop->logger, LOGGER_INFO, "Unhandled Client Request: %s %s", method, url);
     }

--- a/lib/raop.h
+++ b/lib/raop.h
@@ -83,6 +83,7 @@ RAOP_API int raop_is_running(raop_t *raop);
 RAOP_API void raop_stop(raop_t *raop);
 RAOP_API void raop_set_dnssd(raop_t *raop, dnssd_t *dnssd);
 RAOP_API void raop_destroy(raop_t *raop);
+const char *gmt_time_string();
 
 #ifdef __cplusplus
 }

--- a/lib/raop_handlers.h
+++ b/lib/raop_handlers.h
@@ -222,6 +222,9 @@ raop_handler_server_info(raop_conn_t *conn,
     plist_dict_set_item(r_node, "deviceid", device_id_node);
 
     plist_to_xml(r_node, response_data, (uint32_t *) response_datalen);
+    int lastbyte = *response_datalen - 1;
+    response_data[lastbyte] = 0x0;
+    *response_datalen = *response_datalen - 1; //TODO: Check if this does anything
     printf("%s", *response_data);
     plist_free(r_node);
 

--- a/lib/raop_handlers.h
+++ b/lib/raop_handlers.h
@@ -1087,6 +1087,19 @@ raop_handler_set_parameter(raop_conn_t *conn,
     }
 }
 
+static void
+raop_handler_reverse(raop_conn_t *conn,
+                      http_request_t *request, http_response_t *response,
+                      char **response_data, int *response_datalen)
+{
+    logger_log(conn->raop->logger, LOGGER_DEBUG, "raop_handler_reverse");
+    const char* connection;
+    const char* upgrade;
+    connection = http_request_get_header(request, "Connection");
+    upgrade = http_request_get_header(request, "Upgrade");
+    http_response_add_header(response, "Connection", connection);
+    http_response_add_header(response, "Upgrade", upgrade);
+}
 
 static void
 raop_handler_feedback(raop_conn_t *conn,

--- a/lib/raop_handlers.h
+++ b/lib/raop_handlers.h
@@ -1150,10 +1150,35 @@ http_handler_playback_info(raop_conn_t *conn,
     plist_dict_set_item(r_node, "seekableTimeRanges", seekableTimeRanges);
 
     plist_to_xml(r_node, response_data, (uint32_t *) response_datalen);
+    *response_datalen = *response_datalen - 1; //TODO: Check if this does anything
     printf("%s", *response_data);
     plist_free(r_node);
 
     http_response_add_header(response, "Content-Type", "text/x-apple-plist+xml");
+}
+
+static void
+http_handler_set_property(raop_conn_t *conn,
+                      http_request_t *request, http_response_t *response,
+                      char **response_data, int *response_datalen)
+{
+    logger_log(conn->raop->logger, LOGGER_DEBUG, "http_handler_set_property");
+
+    char* urlPiece = (char*) http_request_get_url(request);
+    strremove(urlPiece, "/setProperty?");
+
+    if (!strcmp(urlPiece, "reverseEndTime") || !strcmp(urlPiece, "forwardEndTime") || !strcmp(urlPiece, "actionAtItemEnd")) {
+        plist_t errResponse = plist_new_dict();
+        plist_t errCode = plist_new_uint(0);
+        plist_dict_set_item(errResponse, "errorCode", errCode);
+        plist_to_xml(errResponse, response_data, (uint32_t *) response_datalen);
+        *response_datalen = *response_datalen - 1; //TODO: Check if this does anything
+        printf("%s", *response_data);
+        plist_free(errResponse);
+        http_response_add_header(response, "Content-Type", "text/x-apple-plist+xml");
+    } else {
+        http_response_add_header(response, "Content-Length", "0");
+    }
 }
 
 static void

--- a/lib/raop_handlers.h
+++ b/lib/raop_handlers.h
@@ -61,8 +61,8 @@ raop_handler_info(raop_conn_t *conn,
     /*plist_t txt_airplay_node = plist_new_data(airplay_txt, airplay_txt_len);
     plist_dict_set_item(r_node, "txtAirPlay", txt_airplay_node);*/
 
-    //plist_t device_id_node = plist_new_string(device_id);
-    plist_t device_id_node = plist_new_string("AABBCCDDEEFF");
+    plist_t device_id_node = plist_new_string(device_id);
+    //plist_t device_id_node = plist_new_string("AABBCCDDEEFF");
     plist_dict_set_item(r_node, "deviceID", device_id_node);
 
     uint64_t features = dnssd_get_airplay_features(conn->raop->dnssd);
@@ -75,8 +75,8 @@ raop_handler_info(raop_conn_t *conn,
     plist_t keep_alive_send_stats_as_body_node = plist_new_uint(1);
     plist_dict_set_item(r_node, "keepAliveSendStatsAsBody", keep_alive_send_stats_as_body_node);
 
-    //plist_t mac_address_node = plist_new_string(hw_addr);
-    plist_t mac_address_node = plist_new_string("AA:BB:CC:DD:EE:FF");
+    plist_t mac_address_node = plist_new_string(hw_addr);
+    //plist_t mac_address_node = plist_new_string("AA:BB:CC:DD:EE:FF");
     plist_dict_set_item(r_node, "macAddress", mac_address_node);
 
     plist_t model_node = plist_new_string(GLOBAL_MODEL);

--- a/lib/raop_handlers.h
+++ b/lib/raop_handlers.h
@@ -45,6 +45,10 @@ raop_handler_info(raop_conn_t *conn,
     int hw_addr_raw_len = 0;
     const char *hw_addr_raw = dnssd_get_hw_addr(conn->raop->dnssd, &hw_addr_raw_len);
 
+    char *device_id = calloc(1, 3 * hw_addr_raw_len);
+    utils_hwaddr_airplay(device_id, 3 * hw_addr_raw_len, hw_addr_raw, hw_addr_raw_len);
+    str_replace(device_id, ":", "");
+
     char *hw_addr = calloc(1, 3 * hw_addr_raw_len);
     //int hw_addr_len =
     utils_hwaddr_airplay(hw_addr, 3 * hw_addr_raw_len, hw_addr_raw, hw_addr_raw_len);
@@ -54,71 +58,79 @@ raop_handler_info(raop_conn_t *conn,
 
     plist_t r_node = plist_new_dict();
 
-    plist_t txt_airplay_node = plist_new_data(airplay_txt, airplay_txt_len);
-    plist_dict_set_item(r_node, "txtAirPlay", txt_airplay_node);
+    /*plist_t txt_airplay_node = plist_new_data(airplay_txt, airplay_txt_len);
+    plist_dict_set_item(r_node, "txtAirPlay", txt_airplay_node);*/
+
+    //plist_t device_id_node = plist_new_string(device_id);
+    plist_t device_id_node = plist_new_string("AABBCCDDEEFF");
+    plist_dict_set_item(r_node, "deviceID", device_id_node);
 
     uint64_t features = dnssd_get_airplay_features(conn->raop->dnssd);
     plist_t features_node = plist_new_uint(features);
     plist_dict_set_item(r_node, "features", features_node);
 
+    plist_t keep_alive_low_power_node = plist_new_uint(1);
+    plist_dict_set_item(r_node, "keepAliveLowPower", keep_alive_low_power_node);
+
+    plist_t keep_alive_send_stats_as_body_node = plist_new_uint(1);
+    plist_dict_set_item(r_node, "keepAliveSendStatsAsBody", keep_alive_send_stats_as_body_node);
+
+    //plist_t mac_address_node = plist_new_string(hw_addr);
+    plist_t mac_address_node = plist_new_string("AA:BB:CC:DD:EE:FF");
+    plist_dict_set_item(r_node, "macAddress", mac_address_node);
+
+    plist_t model_node = plist_new_string(GLOBAL_MODEL);
+    plist_dict_set_item(r_node, "model", model_node);
+    
     plist_t name_node = plist_new_string(name);
     plist_dict_set_item(r_node, "name", name_node);
 
+    plist_t source_version_node = plist_new_string(GLOBAL_VERSION);
+    plist_dict_set_item(r_node, "sourceVersion", source_version_node);
+
+    plist_t status_flags_node = plist_new_uint(68);
+    plist_dict_set_item(r_node, "statusFlags", status_flags_node);
+
+    plist_t pi_node = plist_new_string(AIRPLAY_PI);
+    plist_dict_set_item(r_node, "pi", pi_node);
+
+    plist_t pk_node = plist_new_data(pk, pk_len);
+    plist_dict_set_item(r_node, "pk", pk_node);
+
+    plist_t vv_node = plist_new_uint(strtol(AIRPLAY_VV, NULL, 10));
+    plist_dict_set_item(r_node, "vv", vv_node);
+
     plist_t audio_formats_node = plist_new_array();
     plist_t audio_format_0_node = plist_new_dict();
-    plist_t audio_format_0_type_node = plist_new_uint(100);
-    plist_t audio_format_0_audio_input_formats_node = plist_new_uint(0x3fffffc);
-    plist_t audio_format_0_audio_output_formats_node = plist_new_uint(0x3fffffc);
+    plist_t audio_format_0_type_node = plist_new_uint(96);
+    plist_t audio_format_0_audio_input_formats_node = plist_new_uint(0x01000000);
+    plist_t audio_format_0_audio_output_formats_node = plist_new_uint(0x01000000);
     plist_dict_set_item(audio_format_0_node, "type", audio_format_0_type_node);
     plist_dict_set_item(audio_format_0_node, "audioInputFormats", audio_format_0_audio_input_formats_node);
     plist_dict_set_item(audio_format_0_node, "audioOutputFormats", audio_format_0_audio_output_formats_node);
     plist_array_append_item(audio_formats_node, audio_format_0_node);
-    plist_t audio_format_1_node = plist_new_dict();
+    /*plist_t audio_format_1_node = plist_new_dict();
     plist_t audio_format_1_type_node = plist_new_uint(101);
     plist_t audio_format_1_audio_input_formats_node = plist_new_uint(0x3fffffc);
     plist_t audio_format_1_audio_output_formats_node = plist_new_uint(0x3fffffc);
     plist_dict_set_item(audio_format_1_node, "type", audio_format_1_type_node);
     plist_dict_set_item(audio_format_1_node, "audioInputFormats", audio_format_1_audio_input_formats_node);
     plist_dict_set_item(audio_format_1_node, "audioOutputFormats", audio_format_1_audio_output_formats_node);
-    plist_array_append_item(audio_formats_node, audio_format_1_node);
+    plist_array_append_item(audio_formats_node, audio_format_1_node);*/
     plist_dict_set_item(r_node, "audioFormats", audio_formats_node);
-
-    plist_t pi_node = plist_new_string(AIRPLAY_PI);
-    plist_dict_set_item(r_node, "pi", pi_node);
-
-    plist_t vv_node = plist_new_uint(strtol(AIRPLAY_VV, NULL, 10));
-    plist_dict_set_item(r_node, "vv", vv_node);
-
-    plist_t status_flags_node = plist_new_uint(68);
-    plist_dict_set_item(r_node, "statusFlags", status_flags_node);
-
-    plist_t keep_alive_low_power_node = plist_new_uint(1);
-    plist_dict_set_item(r_node, "keepAliveLowPower", keep_alive_low_power_node);
-
-    plist_t source_version_node = plist_new_string(GLOBAL_VERSION);
-    plist_dict_set_item(r_node, "sourceVersion", source_version_node);
-
-    plist_t pk_node = plist_new_data(pk, pk_len);
-    plist_dict_set_item(r_node, "pk", pk_node);
-
-    plist_t keep_alive_send_stats_as_body_node = plist_new_uint(1);
-    plist_dict_set_item(r_node, "keepAliveSendStatsAsBody", keep_alive_send_stats_as_body_node);
-
-    plist_t device_id_node = plist_new_string(hw_addr);
-    plist_dict_set_item(r_node, "deviceID", device_id_node);
 
     plist_t audio_latencies_node = plist_new_array();
     plist_t audio_latencies_0_node = plist_new_dict();
-    plist_t audio_latencies_0_output_latency_micros_node = plist_new_bool(0);
-    plist_t audio_latencies_0_type_node = plist_new_uint(100);
+    plist_t audio_latencies_0_output_latency_micros_node = plist_new_uint(0);
+    plist_t audio_latencies_0_type_node = plist_new_uint(96);
     plist_t audio_latencies_0_audio_type_node = plist_new_string("default");
-    plist_t audio_latencies_0_input_latency_micros_node = plist_new_bool(0);
-    plist_dict_set_item(audio_latencies_0_node, "outputLatencyMicros", audio_latencies_0_output_latency_micros_node);
+    plist_t audio_latencies_0_input_latency_micros_node = plist_new_uint(0);
     plist_dict_set_item(audio_latencies_0_node, "type", audio_latencies_0_type_node);
     plist_dict_set_item(audio_latencies_0_node, "audioType", audio_latencies_0_audio_type_node);
     plist_dict_set_item(audio_latencies_0_node, "inputLatencyMicros", audio_latencies_0_input_latency_micros_node);
+    plist_dict_set_item(audio_latencies_0_node, "outputLatencyMicros", audio_latencies_0_output_latency_micros_node);
     plist_array_append_item(audio_latencies_node, audio_latencies_0_node);
-    plist_t audio_latencies_1_node = plist_new_dict();
+    /*plist_t audio_latencies_1_node = plist_new_dict();
     plist_t audio_latencies_1_output_latency_micros_node = plist_new_bool(0);
     plist_t audio_latencies_1_type_node = plist_new_uint(101);
     plist_t audio_latencies_1_audio_type_node = plist_new_string("default");
@@ -127,42 +139,39 @@ raop_handler_info(raop_conn_t *conn,
     plist_dict_set_item(audio_latencies_1_node, "type", audio_latencies_1_type_node);
     plist_dict_set_item(audio_latencies_1_node, "audioType", audio_latencies_1_audio_type_node);
     plist_dict_set_item(audio_latencies_1_node, "inputLatencyMicros", audio_latencies_1_input_latency_micros_node);
-    plist_array_append_item(audio_latencies_node, audio_latencies_1_node);
+    plist_array_append_item(audio_latencies_node, audio_latencies_1_node);*/
     plist_dict_set_item(r_node, "audioLatencies", audio_latencies_node);
-
-    plist_t model_node = plist_new_string(GLOBAL_MODEL);
-    plist_dict_set_item(r_node, "model", model_node);
-
-    plist_t mac_address_node = plist_new_string(hw_addr);
-    plist_dict_set_item(r_node, "macAddress", mac_address_node);
 
     plist_t displays_node = plist_new_array();
     plist_t displays_0_node = plist_new_dict();
-    plist_t displays_0_uuid_node = plist_new_string("e0ff8a27-6738-3d56-8a16-cc53aacee925");
-    plist_t displays_0_width_physical_node = plist_new_bool(0);
-    plist_t displays_0_height_physical_node = plist_new_bool(0);
+    plist_t displays_0_uuid_node = plist_new_string("e5f7a68d-7b0f-4305-984b-974f677a150b");
+    plist_t displays_0_width_physical_node = plist_new_uint(0);
+    plist_t displays_0_height_physical_node = plist_new_uint(0);
     plist_t displays_0_width_node = plist_new_uint(conn->raop->width);
     plist_t displays_0_height_node = plist_new_uint(conn->raop->height);
     plist_t displays_0_width_pixels_node = plist_new_uint(conn->raop->width);
     plist_t displays_0_height_pixels_node = plist_new_uint(conn->raop->height);
-    plist_t displays_0_rotation_node = plist_new_bool(0);
+    plist_t displays_0_rotation_node = plist_new_bool(1);
     plist_t displays_0_refresh_rate_node = plist_new_uint(conn->raop->refreshRate);
     plist_t displays_0_max_fps_node = plist_new_uint(conn->raop->maxFPS);
     plist_t displays_0_overscanned_node = plist_new_bool(conn->raop->overscanned);
     plist_t displays_0_features = plist_new_uint(14);
 
-    plist_dict_set_item(displays_0_node, "uuid", displays_0_uuid_node);
-    plist_dict_set_item(displays_0_node, "widthPhysical", displays_0_width_physical_node);
+    plist_dict_set_item(displays_0_node, "features", displays_0_features);
+    plist_dict_set_item(displays_0_node, "height", displays_0_height_node);
+    plist_dict_set_item(displays_0_node, "heightPixels", displays_0_height_pixels_node);
     plist_dict_set_item(displays_0_node, "heightPhysical", displays_0_height_physical_node);
     plist_dict_set_item(displays_0_node, "width", displays_0_width_node);
-    plist_dict_set_item(displays_0_node, "height", displays_0_height_node);
     plist_dict_set_item(displays_0_node, "widthPixels", displays_0_width_pixels_node);
-    plist_dict_set_item(displays_0_node, "heightPixels", displays_0_height_pixels_node);
-    plist_dict_set_item(displays_0_node, "rotation", displays_0_rotation_node);
+    plist_dict_set_item(displays_0_node, "widthPhysical", displays_0_width_physical_node);
     plist_dict_set_item(displays_0_node, "refreshRate", displays_0_refresh_rate_node);
-    plist_dict_set_item(displays_0_node, "maxFPS", displays_0_max_fps_node);
     plist_dict_set_item(displays_0_node, "overscanned", displays_0_overscanned_node);
-    plist_dict_set_item(displays_0_node, "features", displays_0_features);
+    plist_dict_set_item(displays_0_node, "rotation", displays_0_rotation_node);
+    plist_dict_set_item(displays_0_node, "uuid", displays_0_uuid_node);
+    
+    //plist_dict_set_item(displays_0_node, "maxFPS", displays_0_max_fps_node);
+    
+    
     plist_array_append_item(displays_node, displays_0_node);
     plist_dict_set_item(r_node, "displays", displays_node);
 
@@ -761,10 +770,11 @@ raop_handler_setup(raop_conn_t *conn,
                                                          conn->raop_ntp, remote, conn->remotelen, aeskey);
         }
 
-        plist_t res_event_port_node = plist_new_uint(conn->raop->port);
+        plist_t res_event_port_node = plist_new_uint(0);
         plist_t res_timing_port_node = plist_new_uint(timing_lport);
-        plist_dict_set_item(res_root_node, "timingPort", res_timing_port_node);
         plist_dict_set_item(res_root_node, "eventPort", res_event_port_node);
+        plist_dict_set_item(res_root_node, "timingPort", res_timing_port_node);
+        
 
         logger_log(conn->raop->logger, LOGGER_DEBUG, "eport = %d, tport = %d", conn->raop->port, timing_lport);
     }
@@ -914,7 +924,7 @@ raop_handler_get_parameter(raop_conn_t *conn,
 
             /* This is a bit ugly, but seems to be how airport works too */
             if ((datalen - (current - data) >= 8) && !strncmp(current, "volume\r\n", 8)) {
-                const char volume[] = "volume: 0.0\r\n";
+                const char volume[] = "volume: 0.000000\r\n";
 
                 http_response_add_header(response, "Content-Type", "text/parameters");
                 *response_data = strdup(volume);
@@ -993,6 +1003,7 @@ raop_handler_feedback(raop_conn_t *conn,
                       http_request_t *request, http_response_t *response,
                       char **response_data, int *response_datalen)
 {
+    //http_response_add_header(response, "Audio-Latency", "0");
     logger_log(conn->raop->logger, LOGGER_DEBUG, "raop_handler_feedback");
 }
 
@@ -1005,8 +1016,11 @@ raop_handler_record(raop_conn_t *conn,
     unsigned int ad = (unsigned int) (((uint64_t) conn->raop->audio_delay_micros) * AUDIO_SAMPLE_RATE / SECOND_IN_USECS);
     snprintf(audio_latency, sizeof(audio_latency), "%u", ad);
     logger_log(conn->raop->logger, LOGGER_DEBUG, "raop_handler_record");
-    http_response_add_header(response, "Audio-Latency", audio_latency);
-    http_response_add_header(response, "Audio-Jack-Status", "connected; type=analog");
+    raop_ntp_cast_start(conn->raop_ntp);
+    //unsigned short timing_lport = conn->raop->timing_lport;
+    //raop_ntp_start(conn->raop_ntp, &timing_lport, conn->raop->max_ntp_timeouts);
+    //http_response_add_header(response, "Audio-Latency", audio_latency);
+    //http_response_add_header(response, "Audio-Jack-Status", "connected; type=digital");
 }
 
 static void

--- a/lib/raop_handlers.h
+++ b/lib/raop_handlers.h
@@ -1093,12 +1093,12 @@ raop_handler_reverse(raop_conn_t *conn,
                       char **response_data, int *response_datalen)
 {
     logger_log(conn->raop->logger, LOGGER_DEBUG, "raop_handler_reverse");
-    const char* connection;
     const char* upgrade;
-    connection = http_request_get_header(request, "Connection");
+    conn->cast_session = http_request_get_header(request, "X-Apple-Session-ID");
+    conn->castsessionlen = strlen(conn->cast_session);
     upgrade = http_request_get_header(request, "Upgrade");
-    http_response_add_header(response, "Connection", connection);
     http_response_add_header(response, "Upgrade", upgrade);
+    http_response_add_header(response, "Content-Length", "0");
 }
 
 static void

--- a/lib/raop_ntp.h
+++ b/lib/raop_ntp.h
@@ -29,6 +29,8 @@ typedef enum timing_protocol_e { NTP, TP_NONE, TP_OTHER, TP_UNSPECIFIED } timing
 
 void raop_ntp_start(raop_ntp_t *raop_ntp, unsigned short *timing_lport, int max_ntp_timeouts);
 
+void raop_ntp_cast_start(raop_ntp_t *raop_ntp);
+
 void raop_ntp_stop(raop_ntp_t *raop_ntp);
 
 unsigned short raop_ntp_get_port(raop_ntp_t *raop_ntp);

--- a/lib/utils.c
+++ b/lib/utils.c
@@ -256,3 +256,37 @@ void ntp_timestamp_to_seconds(uint64_t ntp_timestamp, char *timestamp, size_t ma
     strftime(timestamp, 3, "%S", &ts);
     snprintf(timestamp + 2, 11,".%9.9lu", (unsigned long) ntp_timestamp % SECOND_IN_NSECS);
 }
+
+//https://stackoverflow.com/questions/32413667/replace-all-occurrences-of-a-substring-in-a-string-in-c
+void str_replace(char *target, const char *needle, const char *replacement)
+{
+    char buffer[1024] = { 0 };
+    char *insert_point = &buffer[0];
+    const char *tmp = target;
+    size_t needle_len = strlen(needle);
+    size_t repl_len = strlen(replacement);
+
+    while (1) {
+        const char *p = strstr(tmp, needle);
+
+        // walked past last occurrence of needle; copy remaining part
+        if (p == NULL) {
+            strcpy(insert_point, tmp);
+            break;
+        }
+
+        // copy part before needle
+        memcpy(insert_point, tmp, p - tmp);
+        insert_point += p - tmp;
+
+        // copy replacement string
+        memcpy(insert_point, replacement, repl_len);
+        insert_point += repl_len;
+
+        // adjust pointers, move on
+        tmp = p + needle_len;
+    }
+
+    // write altered string back to target
+    strcpy(target, buffer);
+}

--- a/lib/utils.h
+++ b/lib/utils.h
@@ -41,7 +41,7 @@ inline void concatenate_string(char* s, char* s1)
         s[i + j] = s1[i];
     }
  
-    s[i + j] = '\0';
+    //s[i + j] = '\0';
  
     return;
 }

--- a/lib/utils.h
+++ b/lib/utils.h
@@ -31,5 +31,19 @@ char *utils_data_to_text(const char *data, int datalen);
 void ntp_timestamp_to_time(uint64_t ntp_timestamp, char *timestamp, size_t maxsize);
 void ntp_timestamp_to_seconds(uint64_t ntp_timestamp, char *timestamp, size_t maxsize);
 void str_replace(char *target, const char *needle, const char *replacement);
+inline void concatenate_string(char* s, char* s1)
+{
+    int i;
+ 
+    int j = strlen(s);
+ 
+    for (i = 0; s1[i] != '\0'; i++) {
+        s[i + j] = s1[i];
+    }
+ 
+    s[i + j] = '\0';
+ 
+    return;
+}
 
 #endif

--- a/lib/utils.h
+++ b/lib/utils.h
@@ -46,4 +46,18 @@ inline void concatenate_string(char* s, char* s1)
     return;
 }
 
+inline
+char *strremove(char *str, const char *sub) {
+    char *p, *q, *r;
+    if (*sub && (q = r = strstr(str, sub)) != NULL) {
+        size_t len = strlen(sub);
+        while ((r = strstr(p = r + len, sub)) != NULL) {
+            memmove(q, p, r - p);
+            q += r - p;
+        }
+        memmove(q, p, strlen(p) + 1);
+    }
+    return str;
+}
+
 #endif

--- a/lib/utils.h
+++ b/lib/utils.h
@@ -30,5 +30,6 @@ char *utils_data_to_string(const unsigned char *data, int datalen, int chars_per
 char *utils_data_to_text(const char *data, int datalen);
 void ntp_timestamp_to_time(uint64_t ntp_timestamp, char *timestamp, size_t maxsize);
 void ntp_timestamp_to_seconds(uint64_t ntp_timestamp, char *timestamp, size_t maxsize);
+void str_replace(char *target, const char *needle, const char *replacement);
 
 #endif

--- a/uxplay.cpp
+++ b/uxplay.cpp
@@ -121,7 +121,7 @@ static unsigned short display[5] = {0}, tcp[3] = {0}, udp[3] = {0};
 static bool debug_log = DEFAULT_DEBUG_LOG;
 static int log_level = LOGGER_INFO;
 static bool bt709_fix = false;
-static int max_connections = 2;
+static int max_connections = 3;
 static unsigned short raop_port;
 static unsigned short airplay_port;
 static uint64_t remote_clock_offset = 0;

--- a/uxplay.cpp
+++ b/uxplay.cpp
@@ -1331,7 +1331,7 @@ static int start_dnssd(std::vector<char> hw_addr, std::string name) {
         return 1;
     }
     /* bit 27 of Features determines whether the AirPlay2 client-pairing protocol will be used (1) or not (0) */
-    dnssd_set_airplay_features(dnssd, 27, (int) setup_legacy_pairing);
+    //dnssd_set_airplay_features(dnssd, 27, (int) setup_legacy_pairing);
     return 0;
 }
 
@@ -1759,13 +1759,7 @@ static int start_raop_server (unsigned short display[5], unsigned short tcp[3], 
     raop_start(raop, &raop_port);
     raop_set_port(raop, raop_port);
 
-    if (tcp[2]) {
-        airplay_port = tcp[2];
-    } else {
-        /* is there a problem if this coincides with a randomly-selected tcp raop_mirror_data port? 
-         * probably not, as the airplay port is only used for initial client contact */
-        airplay_port = (raop_port != HIGHEST_PORT ? raop_port + 1 : raop_port - 1);
-    }
+    airplay_port = raop_port;
     if (dnssd) {
         raop_set_dnssd(raop, dnssd);
     } else {


### PR DESCRIPTION
These changes allow UxPlay to implement video casting into its server, and contains the ability to parse URLs sent by the client for information. 
Still needed:

- [ ] Send /event requests and handle /action
- [ ] Figure out bug where YouTube on safari doesn’t work with AirPlay clients