### PR TITLE
add `systemd` service

### DIFF
--- a/uxplay.service
+++ b/uxplay.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=AirPlay Unix mirroring server
+Requires=avahi-daemon
+After=avahi-daemon
+
+[Service]
+Type=simple
+ExecStart=uxplay
+Restart=on-failure
+
+[Install]
+WantedBy=default.target
+


### PR DESCRIPTION
Hello, thanks for this incredible project!

As a regular user, I'd like UxPlay to start automatically as soon as I open my session, and I didn't want to keep a terminal open. Here I propose a minimal systemd service that allows to start UxPlay as a daemon.

This way, we can start uxplay with `systemctl start --user uxplay`. If we want to make it start at login, `systemctl enable --user uxplay` will do it.

Hope this will help!