### PR TITLE
raop_rtp fixes/cleanups to remove unneeded ntp use

### DIFF
--- a/README.html
+++ b/README.html
@@ -8,12 +8,19 @@ developed at the GitHub site <a href="https://github.com/FDH2/UxPlay"
 class="uri">https://github.com/FDH2/UxPlay</a> (where ALL user issues
 should be posted, and latest versions can be found).</strong></h3>
 <ul>
-<li><em><strong>NEW in v1.71</strong>: Support for (YouTube) HLS (HTTP
-Live Streaming) video with the new “-hls” option.</em> Click on the
-airplay icon in the YouTube app to stream video. (You may need to wait
-until advertisements have finished or been skipped before clicking the
-YouTube airplay icon.) <strong>Please report any issues with this new
-feature of UxPlay</strong>.</li>
+<li><p><em><strong>NEW in v1.71</strong>: Support for (YouTube) HLS
+(HTTP Live Streaming) video with the new “-hls” option.</em> Click on
+the airplay icon in the YouTube app to stream video. (You may need to
+wait until advertisements have finished or been skipped before clicking
+the YouTube airplay icon.) <strong>Please report any issues with this
+new feature of UxPlay</strong>.</p>
+<p><strong><em>NEWS</em></strong>: macOS Sequoia clients (15.2 and maybe
+earlier) fail to synchronize their clocks with UxPlay using NTP
+protocol. It is not clear if this is a new macOS bug or feature. UxPlay
+does not need such clock synchronization, and the latest UxPlay code has
+been modified to not use it. Users of Uxplay releases 1.71.1 or earlier
+should use options “-vsync no -reset 0” with macOS Sequoia clients, or
+update to latest UxPlay code.</p></li>
 </ul>
 <h2 id="highlights">Highlights:</h2>
 <ul>

--- a/README.md
+++ b/README.md
@@ -9,6 +9,14 @@
     YouTube airplay icon.) **Please report any issues with this new
     feature of UxPlay**.
 
+    ***NEWS***: macOS Sequoia clients (15.2 and maybe earlier) fail to
+    synchronize their clocks with UxPlay using NTP protocol.  It is not
+    clear if this is a new macOS bug or feature.  UxPlay does not need such
+    clock synchronization, and the latest UxPlay code has been modified to not
+    use it.  Users of Uxplay releases 1.71.1 or earlier should use options
+    "-vsync no -reset 0" with macOS Sequoia clients, or update to latest
+    UxPlay code.
+
 ## Highlights:
 
 -   GPLv3, open source.

--- a/README.txt
+++ b/README.txt
@@ -9,6 +9,14 @@
     YouTube airplay icon.) **Please report any issues with this new
     feature of UxPlay**.
 
+    ***NEWS***: macOS Sequoia clients (15.2 and maybe earlier) fail to
+    synchronize their clocks with UxPlay using NTP protocol. It is not
+    clear if this is a new macOS bug or feature. UxPlay does not need
+    such clock synchronization, and the latest UxPlay code has been
+    modified to not use it. Users of Uxplay releases 1.71.1 or earlier
+    should use options "-vsync no -reset 0" with macOS Sequoia clients,
+    or update to latest UxPlay code.
+
 ## Highlights:
 
 -   GPLv3, open source.

--- a/lib/raop.c
+++ b/lib/raop.c
@@ -765,3 +765,7 @@ void raop_destroy_airplay_video(raop_t *raop) {
         raop->airplay_video = NULL;
     }
 }
+
+uint64_t get_local_time() {
+    return raop_ntp_get_local_time();
+}

--- a/lib/raop.h
+++ b/lib/raop.h
@@ -108,7 +108,8 @@ int airplay_video_service_init(raop_t *raop, unsigned short port, const char *se
 bool register_airplay_video(raop_t *raop, airplay_video_t *airplay_video);
 airplay_video_t *get_airplay_video(raop_t *raop);
 airplay_video_t *deregister_airplay_video(raop_t *raop);
-  
+uint64_t get_local_time();
+
 RAOP_API raop_t *raop_init(raop_callbacks_t *callbacks);
 RAOP_API int raop_init2(raop_t *raop, int nohold, const char *device_id, const char *keyfile);
 RAOP_API void raop_set_log_level(raop_t *raop, int level);

--- a/lib/raop_buffer.c
+++ b/lib/raop_buffer.c
@@ -39,10 +39,11 @@ typedef struct {
     /* Data available */
     int filled;
 
+    uint64_t packet_arrival_time;
+
     /* RTP header */
     unsigned short seqnum;
-    uint64_t rtp_timestamp;
-    uint64_t ntp_timestamp;
+    uint32_t rtp_timestamp;
 
     /* Payload data */
     unsigned int payload_size;
@@ -165,7 +166,7 @@ raop_buffer_decrypt(raop_buffer_t *raop_buffer, unsigned char *data, unsigned ch
 }
 
 int
-raop_buffer_enqueue(raop_buffer_t *raop_buffer, unsigned char *data, unsigned short datalen, uint64_t *ntp_timestamp, uint64_t *rtp_timestamp, int use_seqnum) {
+raop_buffer_enqueue(raop_buffer_t *raop_buffer, unsigned char *data, unsigned short datalen, int use_seqnum) {
     unsigned char empty_packet_marker[] = { 0x00, 0x68, 0x34, 0x00 };
     assert(raop_buffer);
 
@@ -206,8 +207,7 @@ raop_buffer_enqueue(raop_buffer_t *raop_buffer, unsigned char *data, unsigned sh
 
     /* Update the raop_buffer entry header */
     entry->seqnum = seqnum;
-    entry->rtp_timestamp = *rtp_timestamp;
-    entry->ntp_timestamp = *ntp_timestamp;
+    entry->rtp_timestamp = byteutils_get_int_be(data, 4);
     entry->filled = 1;
 
     entry->payload_data = malloc(payload_size);
@@ -228,7 +228,7 @@ raop_buffer_enqueue(raop_buffer_t *raop_buffer, unsigned char *data, unsigned sh
 }
 
 void *
-raop_buffer_dequeue(raop_buffer_t *raop_buffer, unsigned int *length, uint64_t *ntp_timestamp, uint64_t *rtp_timestamp, unsigned short *seqnum, int no_resend) {
+raop_buffer_dequeue(raop_buffer_t *raop_buffer, unsigned int *length, uint32_t *rtp_timestamp, unsigned short *seqnum, int no_resend) {
     assert(raop_buffer);
 
     /* Calculate number of entries in the current buffer */
@@ -261,7 +261,6 @@ raop_buffer_dequeue(raop_buffer_t *raop_buffer, unsigned int *length, uint64_t *
 
     /* Return entry payload buffer */
     *rtp_timestamp = entry->rtp_timestamp;
-    *ntp_timestamp = entry->ntp_timestamp;
     *seqnum = entry->seqnum;
     *length = entry->payload_size;
     entry->payload_size = 0;

--- a/lib/raop_buffer.h
+++ b/lib/raop_buffer.h
@@ -28,8 +28,8 @@ typedef int (*raop_resend_cb_t)(void *opaque, unsigned short seqno, unsigned sho
 raop_buffer_t *raop_buffer_init(logger_t *logger,
                                 const unsigned char *aeskey,
                                 const unsigned char *aesiv);
-int raop_buffer_enqueue(raop_buffer_t *raop_buffer, unsigned char *data, unsigned short datalen, uint64_t *ntp_timestamp, uint64_t *rtp_timestamp, int use_seqnum);
-void *raop_buffer_dequeue(raop_buffer_t *raop_buffer, unsigned int *length, uint64_t *ntp_timestamp, uint64_t *rtp_timestamp, unsigned short *seqnum, int no_resend);
+int raop_buffer_enqueue(raop_buffer_t *raop_buffer, unsigned char *data, unsigned short datalen, int use_seqnum);
+void *raop_buffer_dequeue(raop_buffer_t *raop_buffer, unsigned int *length, uint32_t *rtp_timestamp, unsigned short *seqnum, int no_resend);
 void raop_buffer_handle_resends(raop_buffer_t *raop_buffer, raop_resend_cb_t resend_cb, void *opaque);
 void raop_buffer_flush(raop_buffer_t *raop_buffer, int next_seq);
 

--- a/lib/raop_ntp.h
+++ b/lib/raop_ntp.h
@@ -38,9 +38,12 @@ void raop_ntp_destroy(raop_ntp_t *raop_rtp);
 uint64_t raop_ntp_timestamp_to_nano_seconds(uint64_t ntp_timestamp, bool account_for_epoch_diff);
 uint64_t raop_remote_timestamp_to_nano_seconds(raop_ntp_t *raop_ntp, uint64_t timestamp);
 
-uint64_t raop_ntp_get_local_time(raop_ntp_t *raop_ntp);
+uint64_t raop_ntp_get_local_time();
 uint64_t raop_ntp_get_remote_time(raop_ntp_t *raop_ntp);
 uint64_t raop_ntp_convert_remote_time(raop_ntp_t *raop_ntp, uint64_t remote_time);
 uint64_t raop_ntp_convert_local_time(raop_ntp_t *raop_ntp, uint64_t local_time);
+
+void  raop_ntp_set_video_arrival_offset(raop_ntp_t* raop_ntp, const uint64_t *offset);
+uint64_t raop_ntp_get_video_arrival_offset(raop_ntp_t* raop_ntp);
 
 #endif //RAOP_NTP_H

--- a/uxplay.cpp
+++ b/uxplay.cpp
@@ -1658,7 +1658,8 @@ extern "C" void audio_process (void *cls, raop_ntp_t *ntp, audio_decode_struct *
     }
     if (use_audio) {
         if (!remote_clock_offset) {
-            remote_clock_offset = data->ntp_time_local - data->ntp_time_remote;
+            uint64_t local_time = (data->ntp_time_local ? data->ntp_time_local : get_local_time());
+            remote_clock_offset = local_time - data->ntp_time_remote;
         }
         data->ntp_time_remote = data->ntp_time_remote + remote_clock_offset;
         switch (data->ct) {
@@ -1686,7 +1687,8 @@ extern "C" void video_process (void *cls, raop_ntp_t *ntp, video_decode_struct *
     }
     if (use_video) {
         if (!remote_clock_offset) {
-            remote_clock_offset = data->ntp_time_local - data->ntp_time_remote;
+            uint64_t local_time = (data->ntp_time_local ? data->ntp_time_local : get_local_time());
+            remote_clock_offset = local_time - data->ntp_time_remote;
         }
         data->ntp_time_remote = data->ntp_time_remote + remote_clock_offset;
         video_renderer_render_buffer(data->data, &(data->data_len), &(data->nal_count), &(data->ntp_time_remote));


### PR DESCRIPTION
Fixes issue with macOS Sequoia 15.2 clients that fail to synchronize clock with NTP Protocol (new feature/bug in macOS)