### PR TITLE
Revert ancient change (in RPiPlay) to raop_rtp_mirror.c

### DIFF
--- a/lib/raop_rtp_mirror.c
+++ b/lib/raop_rtp_mirror.c
@@ -906,13 +906,13 @@ void raop_rtp_mirror_stop(raop_rtp_mirror_t *raop_rtp_mirror) {
     raop_rtp_mirror->running = 0;
     MUTEX_UNLOCK(raop_rtp_mirror->run_mutex);
 
+    /* Join the thread */
+    THREAD_JOIN(raop_rtp_mirror->thread_mirror);
+
     if (raop_rtp_mirror->mirror_data_sock != -1) {
         closesocket(raop_rtp_mirror->mirror_data_sock);
         raop_rtp_mirror->mirror_data_sock = -1;
     }
-
-    /* Join the thread */
-    THREAD_JOIN(raop_rtp_mirror->thread_mirror);
 
     /* Mark thread as joined */
     MUTEX_LOCK(raop_rtp_mirror->run_mutex);


### PR DESCRIPTION
This was an incorrect transcription in RPiPlay of  changes in
https://github.com/jiangban/AirplayServer/commit/64b108f3bc3ee8af21f5d27ef37eaf40dd183d10
may fix #390 