### PR TITLE
fix: Fix missing htonll definition when building for Windows

### DIFF
--- a/lib/byteutils.c
+++ b/lib/byteutils.c
@@ -31,6 +31,9 @@
 # ifndef ntonll
 #  define ntohll(x) ((1==ntohl(1)) ? (x) : (((uint64_t)ntohl((x) & 0xFFFFFFFFUL)) << 32) | ntohl((uint32_t)((x) >> 32)))
 # endif
+#ifndef htonll
+#  define htonll(x) ((1==ntohl(1)) ? (x) : (((uint64_t)htonl((x) & 0xFFFFFFFFUL)) << 32) | htonl((uint32_t)((x) >> 32)))
+#endif
 #else
 #  ifndef htonll
 #   ifdef SYS_ENDIAN_H


### PR DESCRIPTION
This pull request fixes an issue where htonll is not found when building for Windows.

**Changes:**
Added a custom htonll implementation for Windows compatibility.
Ensured htonll is properly defined using htonl and bitwise operations.
Updated header guards to prevent multiple definitions.

**Tested on:**
Windows (MinGW)