### PR TITLE
Use waylandsink in Wayland sessions for GStreamer 1.16+

### DIFF
--- a/README.html
+++ b/README.html
@@ -8,6 +8,10 @@ developed at the GitHub site <a href="https://github.com/FDH2/UxPlay"
 class="uri">https://github.com/FDH2/UxPlay</a> (where ALL user issues
 should be posted, and latest versions can be found).</strong></h3>
 <ul>
+<li><p><strong>NEW on github</strong>: option -ca (with no filename
+given) will now render Apple Music cover art (in audio-only mode) inside
+UxPlay. (-ca <code>&lt;filename&gt;</code> will continue to export cover
+art for display by an external viewer).</p></li>
 <li><p><strong>NEW in v1.72</strong>: Improved Support for (YouTube) HLS
 (HTTP Live Streaming) video with the new “-hls” option (introduced in
 1.71).* <strong>Only streaming from the YouTube iOS app (in "m3u8"
@@ -107,7 +111,8 @@ distribution’s <strong>GStreamer plugin packages</strong> you should
 also install.</p></li>
 <li><p>For Audio-only mode (Apple Music, etc.) best quality is obtained
 with the option “uxplay -async”, but there is then a 2 second latency
-imposed by iOS.</p></li>
+imposed by iOS. Use option “uxplay -ca” to display any “Cover Art” that
+accompanies the audio.</p></li>
 <li><p>If you are using UxPlay just to mirror the client’s screen
 (without showing videos that need audio synchronized with video), it is
 best to use the option “uxplay -vsync no”.</p></li>
@@ -621,12 +626,14 @@ some video to be played at 60 frames per second. (You can see what
 framerate is actually streaming by using -vs fpsdisplaysink, and/or
 -FPSdata.) When using this, you should use the default timestamp-based
 synchronization option <code>-vsync</code>.</p></li>
-<li><p>Since UxPlay-1.54, you can display the accompanying “Cover Art”
-from sources like Apple Music in Audio-Only (ALAC) mode: run
+<li><p>You can now display (inside UxPlay) the accompanying “Cover Art”
+from sources like Apple Music in Audio-Only (ALAC) mode with the option
+<code>uxplay -ca</code>. <em>The older method of exporting cover art to
+an external viewer remains available: run
 “<code>uxplay -ca &lt;name&gt; &amp;</code>” in the background, then run
 a image viewer with an autoreload feature: an example is “feh”: run
 “<code>feh -R 1 &lt;name&gt;</code>” in the foreground; terminate feh
-and then Uxplay with “<code>ctrl-C fg ctrl-C</code>”.</p></li>
+and then Uxplay with “<code>ctrl-C fg ctrl-C</code>”</em>.</p></li>
 </ul>
 <p>By default, GStreamer uses an algorithm to search for the best
 “videosink” (GStreamer’s term for a graphics driver to display images)
@@ -1067,11 +1074,11 @@ starts (set it in the .uxplay startup file, where it is stored as
 cleartext.) All users must then know this password. This uses HTTP md5
 Digest authentication, which is now regarded as providing weak security,
 but it is only used to validate the uxplay password, and no user
-credentials are exposed. _Note: -pin and -pw are alternatives: if both
-are specified at startup, the earlier of these two options is discarded.
-If <em>pwd</em> is not specified, a random 4-digit pin code is
-displayed, and must be entered on the client at <strong>each</strong>
-new conenction.</p>
+credentials are exposed. If <em>pwd</em> is <strong>not</strong>
+specified, a random 4-digit pin code is displayed, and must be entered
+on the client at <strong>each</strong> new connection. <em>Note: -pin
+and -pw are alternatives: if both are specified at startup, the earlier
+of these two options is discarded.</em></p>
 <p><strong>-vsync [x]</strong> (In Mirror mode:) this option
 (<strong>now the default</strong>) uses timestamps to synchronize audio
 with video on the server, with an optional audio delay in (decimal)
@@ -1236,6 +1243,9 @@ client. Values in the range [0.0, 10.0] seconds are allowed, and will be
 converted to a whole number of microseconds. Default is 0.25 sec (250000
 usec). <em>(However, the client appears to ignore this reported latency,
 so this option seems non-functional.)</em></p>
+<p><strong>-ca</strong> (without specifying a filename) now displays
+“cover art” that accompanies Apple Music when played in “Audio-only”
+(ALAC) mode.</p>
 <p><strong>-ca <em>filename</em></strong> provides a file (where
 <em>filename</em> can include a full path) used for output of “cover
 art” (from Apple Music, <em>etc.</em>,) in audio-only ALAC mode. This
@@ -1700,6 +1710,8 @@ an AppleTV6,2 with sourceVersion 380.20.1 (an AppleTV 4K 1st gen,
 introduced 2017, running tvOS 12.2.1), so it does not seem to matter
 what version UxPlay claims to be.</p>
 <h1 id="changelog">Changelog</h1>
+<p>xxxx 2025-06-18 Render Audio cover-art inside UxPlay with -ca option
+(no file specified). Update llhttp to 9.3.0</p>
 <p>1.72.1 2025-06-06 minor update: fix regression in -reg option; add
 option -rc <rcfile> to specify initialization file; add “-nc no” to
 unset “-nc” option (for macOS users, where -nc is default); add

--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 ### **Now developed at the GitHub site <https://github.com/FDH2/UxPlay> (where ALL user issues should be posted, and latest versions can be found).**
 
+-   **NEW on github**:  option -ca (with no filename given) will now render
+    Apple Music cover art (in audio-only mode) inside
+    UxPlay. (-ca `<filename>` will continue to export cover art for
+    display by an external viewer).
+
 -   **NEW in v1.72**: Improved Support for (YouTube) HLS (HTTP Live Streaming)
     video with the new "-hls" option (introduced in 1.71).* **Only streaming from the YouTube iOS app
     (in \"m3u8\" protocol) is currently supported**: (streaming using the AirPlay icon in a browser window
@@ -93,7 +98,8 @@ status](https://repology.org/badge/vertical-allrepos/uxplay.svg)](https://repolo
 
 -   For Audio-only mode (Apple Music, etc.) best quality is obtained
     with the option "uxplay -async", but there is then a 2 second
-    latency imposed by iOS.
+    latency imposed by iOS.  Use option "uxplay -ca" to display any "Cover Art" that
+    accompanies the audio.
 
 -   If you are using UxPlay just to mirror the client's screen (without
     showing videos that need audio synchronized with video), it is best to
@@ -606,12 +612,14 @@ value advances it.)
     -FPSdata.) When using this, you should use the default
     timestamp-based synchronization option `-vsync`.
 
--   Since UxPlay-1.54, you can display the accompanying "Cover Art" from
-    sources like Apple Music in Audio-Only (ALAC) mode: run
+-   You can now  display (inside UxPlay)  the accompanying "Cover Art" from
+    sources like Apple Music in Audio-Only (ALAC) mode with the option
+    `uxplay -ca`. _The older method of exporting cover art to an external
+    viewer remains available: run
     "`uxplay -ca <name> &`" in the background, then run a image viewer
     with an autoreload feature: an example is "feh": run
     "`feh -R 1 <name>`" in the foreground; terminate feh and then Uxplay
-    with "`ctrl-C fg ctrl-C`".
+    with "`ctrl-C fg ctrl-C`"_.
 
 By default, GStreamer uses an algorithm to search for the best
 "videosink" (GStreamer's term for a graphics driver to display images)
@@ -1060,11 +1068,11 @@ can be controlled with a password set when uxplay starts (set it in
 the .uxplay startup file, where it is stored as cleartext.)  All users must
 then know this password.    This uses HTTP md5 Digest authentication,
 which is now regarded as providing weak security, but it is only used to
-validate the uxplay password, and no user credentials are exposed.   _Note:
--pin and -pw are alternatives: if both are specified at startup, the
-earlier of these two options is discarded.  If *pwd* is not specified,
-a random 4-digit pin code is displayed, and must be entered on the client
-at **each** new conenction.
+validate the uxplay password, and no user credentials are exposed.
+If *pwd* is **not** specified, a random 4-digit pin code is displayed, and must
+be entered on the client at **each** new connection.
+_Note: -pin and -pw are alternatives: if both are specified at startup, the
+earlier of these two options is discarded._
 
 **-vsync \[x\]** (In Mirror mode:) this option (**now the default**)
 uses timestamps to synchronize audio with video on the server, with an
@@ -1244,6 +1252,9 @@ Audio-only (ALAC), that is reported to the client. Values in the range
 number of microseconds. Default is 0.25 sec (250000 usec). *(However,
 the client appears to ignore this reported latency, so this option seems
 non-functional.)*
+
+**-ca**  (without specifying a filename) now displays "cover art"
+  that accompanies Apple Music when played in "Audio-only" (ALAC) mode.
 
 **-ca *filename*** provides a file (where *filename* can include a full
 path) used for output of "cover art" (from Apple Music, *etc.*,) in
@@ -1731,6 +1742,9 @@ introduced 2017, running tvOS 12.2.1), so it does not seem to matter
 what version UxPlay claims to be.
 
 # Changelog
+xxxx  2025-06-18 Render Audio cover-art inside UxPlay with -ca option (no file
+specified). Update llhttp to 9.3.0
+
 1.72.1 2025-06-06  minor update: fix regression in -reg option; add option
 -rc <rcfile> to specify initialization file; add "-nc no" to unset "-nc"
 option (for macOS users, where -nc is default); add user-installable

--- a/README.txt
+++ b/README.txt
@@ -2,6 +2,11 @@
 
 ### **Now developed at the GitHub site <https://github.com/FDH2/UxPlay> (where ALL user issues should be posted, and latest versions can be found).**
 
+-   **NEW on github**: option -ca (with no filename given) will now
+    render Apple Music cover art (in audio-only mode) inside UxPlay.
+    (-ca `<filename>` will continue to export cover art for display by
+    an external viewer).
+
 -   **NEW in v1.72**: Improved Support for (YouTube) HLS (HTTP Live
     Streaming) video with the new "-hls" option (introduced in 1.71).\*
     **Only streaming from the YouTube iOS app (in \"m3u8\" protocol) is
@@ -100,7 +105,8 @@ status](https://repology.org/badge/vertical-allrepos/uxplay.svg)](https://repolo
 
 -   For Audio-only mode (Apple Music, etc.) best quality is obtained
     with the option "uxplay -async", but there is then a 2 second
-    latency imposed by iOS.
+    latency imposed by iOS. Use option "uxplay -ca" to display any
+    "Cover Art" that accompanies the audio.
 
 -   If you are using UxPlay just to mirror the client's screen (without
     showing videos that need audio synchronized with video), it is best
@@ -620,12 +626,13 @@ value advances it.)
     -FPSdata.) When using this, you should use the default
     timestamp-based synchronization option `-vsync`.
 
--   Since UxPlay-1.54, you can display the accompanying "Cover Art" from
-    sources like Apple Music in Audio-Only (ALAC) mode: run
-    "`uxplay -ca <name> &`" in the background, then run a image viewer
-    with an autoreload feature: an example is "feh": run
-    "`feh -R 1 <name>`" in the foreground; terminate feh and then Uxplay
-    with "`ctrl-C fg ctrl-C`".
+-   You can now display (inside UxPlay) the accompanying "Cover Art"
+    from sources like Apple Music in Audio-Only (ALAC) mode with the
+    option `uxplay -ca`. *The older method of exporting cover art to an
+    external viewer remains available: run "`uxplay -ca <name> &`" in
+    the background, then run a image viewer with an autoreload feature:
+    an example is "feh": run "`feh -R 1 <name>`" in the foreground;
+    terminate feh and then Uxplay with "`ctrl-C fg ctrl-C`"*.
 
 By default, GStreamer uses an algorithm to search for the best
 "videosink" (GStreamer's term for a graphics driver to display images)
@@ -1080,11 +1087,11 @@ access can be controlled with a password set when uxplay starts (set it
 in the .uxplay startup file, where it is stored as cleartext.) All users
 must then know this password. This uses HTTP md5 Digest authentication,
 which is now regarded as providing weak security, but it is only used to
-validate the uxplay password, and no user credentials are exposed.
-\_Note: -pin and -pw are alternatives: if both are specified at startup,
-the earlier of these two options is discarded. If *pwd* is not
-specified, a random 4-digit pin code is displayed, and must be entered
-on the client at **each** new conenction.
+validate the uxplay password, and no user credentials are exposed. If
+*pwd* is **not** specified, a random 4-digit pin code is displayed, and
+must be entered on the client at **each** new connection. *Note: -pin
+and -pw are alternatives: if both are specified at startup, the earlier
+of these two options is discarded.*
 
 **-vsync \[x\]** (In Mirror mode:) this option (**now the default**)
 uses timestamps to synchronize audio with video on the server, with an
@@ -1264,6 +1271,9 @@ Audio-only (ALAC), that is reported to the client. Values in the range
 number of microseconds. Default is 0.25 sec (250000 usec). *(However,
 the client appears to ignore this reported latency, so this option seems
 non-functional.)*
+
+**-ca** (without specifying a filename) now displays "cover art" that
+accompanies Apple Music when played in "Audio-only" (ALAC) mode.
 
 **-ca *filename*** provides a file (where *filename* can include a full
 path) used for output of "cover art" (from Apple Music, *etc.*,) in
@@ -1750,6 +1760,9 @@ introduced 2017, running tvOS 12.2.1), so it does not seem to matter
 what version UxPlay claims to be.
 
 # Changelog
+
+xxxx 2025-06-18 Render Audio cover-art inside UxPlay with -ca option (no
+file specified). Update llhttp to 9.3.0
 
 1.72.1 2025-06-06 minor update: fix regression in -reg option; add
 option -rc `<rcfile>`{=html} to specify initialization file; add "-nc

--- a/lib/raop.h
+++ b/lib/raop.h
@@ -82,6 +82,7 @@ struct raop_callbacks_s {
     void  (*audio_set_volume)(void *cls, float volume);
     void  (*audio_set_metadata)(void *cls, const void *buffer, int buflen);
     void  (*audio_set_coverart)(void *cls, const void *buffer, int buflen);
+    void  (*audio_stop_coverart_rendering) (void* cls);
     void  (*audio_remote_control_id)(void *cls, const char *dacp_id, const char *active_remote_header);
     void  (*audio_set_progress)(void *cls, unsigned int start, unsigned int curr, unsigned int end);
     void  (*audio_get_format)(void *cls, unsigned char *ct, unsigned short *spf, bool *usingScreen, bool *isMedia, uint64_t *audioFormat);
@@ -99,8 +100,8 @@ struct raop_callbacks_s {
     void  (*on_video_rate) (void *cls, const float rate);
     void  (*on_video_stop) (void *cls);
     void  (*on_video_acquire_playback_info) (void *cls, playback_info_t *playback_video);
-  
 };
+
 typedef struct raop_callbacks_s raop_callbacks_t;
 raop_ntp_t *raop_ntp_init(logger_t *logger, raop_callbacks_t *callbacks, const char *remote,
                           int remote_addr_len, unsigned short timing_rport,

--- a/lib/raop_handlers.h
+++ b/lib/raop_handlers.h
@@ -1191,6 +1191,10 @@ raop_handler_teardown(raop_conn_t *conn,
         if (conn->raop_rtp) {
             /* Stop our audio RTP session */
             raop_rtp_stop(conn->raop_rtp);
+            /* stop any  coverart rendering */
+            if (conn->raop->callbacks.audio_stop_coverart_rendering) {
+                conn->raop->callbacks.audio_stop_coverart_rendering(conn->raop->callbacks.cls);
+            }
         }
     } else if (teardown_110) {
         conn->raop->callbacks.video_reset(conn->raop->callbacks.cls);	

--- a/renderers/video_renderer.h
+++ b/renderers/video_renderer.h
@@ -58,13 +58,14 @@ void video_renderer_set_start(float position);
 void video_renderer_resume ();
 bool video_renderer_is_paused();
 uint64_t  video_renderer_render_buffer (unsigned char* data, int *data_len, int *nal_count, uint64_t *ntp_time);
+void video_renderer_display_jpeg(const void *data, int *data_len);
 void video_renderer_flush ();
 unsigned int video_renderer_listen(void *loop, int id);
 void video_renderer_destroy ();
 void video_renderer_size(float *width_source, float *height_source, float *width, float *height);
 bool waiting_for_x11_window();
 bool video_get_playback_info(double *duration, double *position, float *rate, bool *buffer_empty, bool *buffer_full);
-int video_renderer_choose_codec(bool is_h265);
+int video_renderer_choose_codec (bool video_is_jpeg, bool video_is_h265);
 unsigned int video_renderer_listen(void *loop, int id);
 unsigned int video_reset_callback(void *loop);
 #ifdef __cplusplus

--- a/uxplay.1
+++ b/uxplay.1
@@ -115,6 +115,8 @@ UxPlay 1.72: An open\-source AirPlay mirroring (+ audio streaming) server:
 .TP
 \fB\-al\fR x     Audio latency in seconds (default 0.25) reported to client.
 .TP
+\fB\-ca\fR       Display cover-art in AirPlay Audio (ALAC) mode.
+.TP
 \fB\-ca\fI fn \fR   In Airplay Audio (ALAC) mode, write cover-art to file fn.
 .TP
 \fB\-md\fI fn \fR   In Airplay Audio (ALAC) mode, write metadata text to file fn.

--- a/uxplay.cpp
+++ b/uxplay.cpp
@@ -35,6 +35,7 @@
 #include <cstdio>
 #include <stdarg.h>
 #include <math.h>
+#include <gst/gst.h>
 
 #ifdef _WIN32  /*modifications for Windows compilation */
 #include <glib.h>
@@ -2362,6 +2363,16 @@ int main (int argc, char *argv[]) {
     if (config_file.length()) {
         read_config_file(config_file.c_str(), argv[0]);
     }
+
+    guint major, minor, micro, nano;
+    gst_version (&major, &minor, &micro, &nano);
+    if (major >= 1 && minor >= 16) {
+    	const char *xdg_session_type = getenv("XDG_SESSION_TYPE");
+    	if (xdg_session_type && strcmp(xdg_session_type, "wayland") == 0) {
+            videosink = "waylandsink";
+    	}
+    }
+
     parse_arguments (argc, argv);
 
     log_level = (debug_log ? LOGGER_DEBUG_DATA : LOGGER_INFO);

--- a/uxplay.cpp
+++ b/uxplay.cpp
@@ -1970,6 +1970,12 @@ extern "C" void audio_set_coverart(void *cls, const void *buffer, int buflen) {
     }
 }
 
+extern "C" void audio_stop_coverart_rendering(void *cls) {
+    if (render_coverart) {
+	video_reset(cls);
+    }
+}
+
 extern "C" void audio_set_progress(void *cls, unsigned int start, unsigned int curr, unsigned int end) {
     int duration = (int)  (end  - start)/44100;
     int position = (int)  (curr - start)/44100;
@@ -2149,6 +2155,7 @@ static int start_raop_server (unsigned short display[5], unsigned short tcp[3], 
     raop_cbs.video_report_size = video_report_size;
     raop_cbs.audio_set_metadata = audio_set_metadata;
     raop_cbs.audio_set_coverart = audio_set_coverart;
+    raop_cbs.audio_stop_coverart_rendering = audio_stop_coverart_rendering;
     raop_cbs.audio_set_progress = audio_set_progress;
     raop_cbs.report_client_request = report_client_request;
     raop_cbs.display_pin = display_pin;

--- a/uxplay.cpp
+++ b/uxplay.cpp
@@ -129,6 +129,7 @@ static bool dump_audio = false;
 static unsigned char audio_type = 0x00;
 static unsigned char previous_audio_type = 0x00;
 static bool fullscreen = false;
+static bool render_coverart = false;
 static std::string coverart_filename = "";
 static std::string metadata_filename = "";
 static bool do_append_hostname = true;
@@ -714,7 +715,7 @@ static void print_info (char *name) {
     printf("          osssink,oss4sink,osxaudiosink,wasapisink,directsoundsink.\n");
     printf("-as 0     (or -a)  Turn audio off, streamed video only\n");
     printf("-al x     Audio latency in seconds (default 0.25) reported to client.\n");
-    printf("-ca <fn>  In Airplay Audio (ALAC) mode, write cover-art to file <fn>\n");
+    printf("-ca [<fn>]In Audio (ALAC) mode, render cover-art [or write to file <fn>]\n");
     printf("-md <fn>  In Airplay Audio (ALAC) mode, write metadata text to file <fn>\n");
     printf("-reset n  Reset after n seconds of client silence (default n=%d, 0=never)\n", MISSED_FEEDBACK_LIMIT);
     printf("-nofreeze Do NOT leave frozen screen in place after reset\n");
@@ -1154,20 +1155,20 @@ static void parse_arguments (int argc, char *argv[]) {
                 if (!file_has_write_access(fn)) {
                     fprintf(stderr, "%s cannot be written to:\noption \"-admp <fn>\" must be to a file with write access\n", fn);
                     exit(1);
-                }   		
+                }
             }
         } else if (arg  == "-ca" ) {
-            if (option_has_value(i, argc, arg, argv[i+1])) {
+            if (i < argc - 1 && *argv[i+1] != '-') {
                 coverart_filename.erase();
                 coverart_filename.append(argv[++i]);
                 const char *fn = coverart_filename.c_str();
+                render_coverart = false;
                 if (!file_has_write_access(fn)) {
                     fprintf(stderr, "%s cannot be written to:\noption \"-ca <fn>\" must be to a file with write access\n", fn);
                     exit(1);
                 }   
             } else {
-                fprintf(stderr,"option -ca must be followed by a filename for cover-art output\n");
-                exit(1);
+                render_coverart = true;
             }
         } else if (arg  == "-md" ) {
             if (option_has_value(i, argc, arg, argv[i+1])) {
@@ -1175,7 +1176,7 @@ static void parse_arguments (int argc, char *argv[]) {
                 metadata_filename.append(argv[++i]);
                 const char *fn = metadata_filename.c_str();
                 if (!file_has_write_access(fn)) {
-                    fprintf(stderr, "%s cannot be written to:\noption \"-ca <fn>\" must be to a file with write access\n", fn);
+                    fprintf(stderr, "%s cannot be written to:\noption \"-md <fn>\" must be to a file with write access\n", fn);
                     exit(1);
                 }   
             } else {
@@ -1689,7 +1690,7 @@ extern "C" void video_reset(void *cls) {
 
 extern "C" int video_set_codec(void *cls, video_codec_t codec) {
     bool video_is_h265 = (codec == VIDEO_CODEC_H265);
-    return video_renderer_choose_codec(video_is_h265);
+    return video_renderer_choose_codec(false, video_is_h265);
 }
 
 extern "C" void display_pin(void *cls, char *pin) {
@@ -1963,6 +1964,9 @@ extern "C" void audio_set_coverart(void *cls, const void *buffer, int buflen) {
     if (buffer && coverart_filename.length()) {
         write_coverart(coverart_filename.c_str(), buffer, buflen);
         LOGI("coverart size %d written to %s", buflen,  coverart_filename.c_str());
+    } else if (buffer && render_coverart) {
+        video_renderer_choose_codec(true, false);  /* video_is_jpeg = true */
+	video_renderer_display_jpeg(buffer, &buflen);
     }
 }
 


### PR DESCRIPTION
Use waylandsink instead of xvimagesink/ximagesink in Wayland sessions.