### PR TITLE
Tell the user what he has to do next

### DIFF
--- a/uxplay.cpp
+++ b/uxplay.cpp
@@ -175,6 +175,7 @@ static guint missed_feedback_limit = MISSED_FEEDBACK_LIMIT;
 static guint missed_feedback = 0;
 static guint playbin_version = DEFAULT_PLAYBIN_VERSION;
 static bool reset_httpd = false;
+const char* lang = std::getenv("LANG");
 /* logging */
 
 static void log(int level, const char* format, ...) {
@@ -2613,6 +2614,21 @@ int main (int argc, char *argv[]) {
         stop_dnssd();
         goto cleanup;
     }
+    // TODO: use gettext for propper translations
+    const char* helptext1;
+    const char* helptext2;
+    if (lang != nullptr && strcmp(lang, "ru_RU.UTF-8") == 0) {
+		helptext1 = "Компьютер и iPhone/iPad должны быть подключены к одной сети";
+		helptext2 = "Запустите \"Повтор экрана\" на iPhone/iPad и выберите";
+	} else {
+		helptext1 = "Your computer and iPhone/iPad must be in one network";
+		helptext2 = "Run \"Screen Mirroring\" on iPhone/iPad and choose";
+	}
+    LOGI("");
+    LOGI("---------------------------------------------");
+    LOGI("---> %s", helptext1);
+    LOGI("---> %s \"%s\"", helptext2, server_name.c_str());
+    LOGI("----------------------------------------------");
     reconnect:
     compression_type = 0;
     close_window = new_window_closing_behavior;


### PR DESCRIPTION
It was not obvious what had to be done after running uxplay. I have added some text, telling the user what he has to do next.

I have also made an icon and desktop file in the ROSA Linux package of uxplay (see https://abf.rosa.ru/import/uxplay).

Now users can launch it without a manual. It is worse than a GUI, but better then nothing, I think.

<img width="666" height="576" alt="image" src="https://github.com/user-attachments/assets/e7c88755-2a8c-43c7-9e1d-c92ed834fc33" />

<img width="785" height="410" alt="image" src="https://github.com/user-attachments/assets/827761ee-cc6b-4d44-b949-33beb6dc33db" />
