### PR TITLE
MP4 Containerisation

### DIFF
--- a/renderers/CMakeLists.txt
+++ b/renderers/CMakeLists.txt
@@ -41,7 +41,7 @@ pkg_check_modules(GST REQUIRED    gstreamer-1.0>=1.4
 add_library( renderers
              STATIC
              audio_renderer.c
-	           video_renderer.c
+             video_renderer.c
              mux_renderer.c)
 
 target_link_libraries ( renderers PUBLIC airplay )

--- a/renderers/mux_renderer.c
+++ b/renderers/mux_renderer.c
@@ -26,6 +26,7 @@
 static logger_t *logger = NULL;
 static gchar *output_filename = NULL;
 static int file_count = 0;
+static gboolean no_audio;
 
 typedef struct mux_renderer_s {
     GstElement *pipeline;
@@ -50,8 +51,9 @@ static const char aac_eld_caps[] = "audio/mpeg,mpegversion=(int)4,channels=(int)
 static const char alac_caps[] = "audio/x-alac,mpegversion=(int)4,channels=(int)2,rate=(int)44100,stream-format=raw,codec_data=(buffer)"
                                 "00000024""616c6163""00000000""00000160""0010280a""0e0200ff""00000000""00000000""0000ac44";
 
-void mux_renderer_init(logger_t *render_logger, const char *filename) {
+void mux_renderer_init(logger_t *render_logger, const char *filename, bool use_audio) {
     logger = render_logger;
+    no_audio = !use_audio;
     if (output_filename) {
         g_free(output_filename);
     }
@@ -61,6 +63,9 @@ void mux_renderer_init(logger_t *render_logger, const char *filename) {
 }
 
 void mux_renderer_choose_audio_codec(unsigned char audio_ct) {
+    if (no_audio) {
+        return;
+    }
     if (renderer && renderer->audio_ct != audio_ct) {
         logger_log(logger, LOGGER_INFO, "Audio codec changed, restarting mux renderer");
         mux_renderer_stop();
@@ -117,22 +122,23 @@ void mux_renderer_start(void) {
         g_string_append(launch, "h264parse ! ");
     }
     g_string_append(launch, "mux. ");
-    
-    g_string_append(launch, "appsrc name=audio_src format=time is-live=true ! queue ! ");
-    switch (renderer->audio_ct) {
-    case 8:
-        g_string_append(launch, "avdec_aac ! ");
-        break;
-    case 2:
-        g_string_append(launch, "avdec_alac ! ");
-        break;
-    default:
-        g_string_append(launch, "avdec_aac ! ");
-        break;
-    }
-    g_string_append(launch, "audioconvert ! audioresample ! ");
-    g_string_append(launch, "avenc_aac ! aacparse ! mux. ");
-    
+
+    if (!no_audio) {
+        g_string_append(launch, "appsrc name=audio_src format=time is-live=true ! queue ! ");
+        switch (renderer->audio_ct) {
+        case 8:
+            g_string_append(launch, "avdec_aac ! ");
+            break;
+        case 2:
+            g_string_append(launch, "avdec_alac ! ");
+            break;
+        default:
+            g_string_append(launch, "avdec_aac ! ");
+            break;
+        }
+        g_string_append(launch, "audioconvert ! audioresample ! ");
+        g_string_append(launch, "avenc_aac ! aacparse ! mux. ");
+    }    
     g_string_append(launch, "mp4mux name=mux ! filesink name=filesink location=");
     g_string_append(launch, filename);
     
@@ -149,7 +155,9 @@ void mux_renderer_start(void) {
     }
     
     renderer->video_appsrc = gst_bin_get_by_name(GST_BIN(renderer->pipeline), "video_src");
-    renderer->audio_appsrc = gst_bin_get_by_name(GST_BIN(renderer->pipeline), "audio_src");
+    if (!no_audio) {
+        renderer->audio_appsrc = gst_bin_get_by_name(GST_BIN(renderer->pipeline), "audio_src");
+    }
     renderer->filesink = gst_bin_get_by_name(GST_BIN(renderer->pipeline), "filesink");
     renderer->bus = gst_element_get_bus(renderer->pipeline);
     
@@ -160,21 +168,23 @@ void mux_renderer_start(void) {
     }
     g_object_set(renderer->video_appsrc, "caps", video_caps, NULL);
     gst_caps_unref(video_caps);
-    
-    switch (renderer->audio_ct) {
-    case 8:
-        audio_caps = gst_caps_from_string(aac_eld_caps);
-        break;
-    case 2:
-        audio_caps = gst_caps_from_string(alac_caps);
-        break;
-    default:
-        audio_caps = gst_caps_from_string(aac_eld_caps);
-        break;
+
+    if (!no_audio) {
+        switch (renderer->audio_ct) {
+        case 8:
+            audio_caps = gst_caps_from_string(aac_eld_caps);
+            break;
+        case 2:
+            audio_caps = gst_caps_from_string(alac_caps);
+            break;
+        default:
+            audio_caps = gst_caps_from_string(aac_eld_caps);
+            break;
+        } 
+        g_object_set(renderer->audio_appsrc, "caps", audio_caps, NULL);
+        gst_caps_unref(audio_caps);
     }
-    g_object_set(renderer->audio_appsrc, "caps", audio_caps, NULL);
-    gst_caps_unref(audio_caps);
-    
+
     gst_element_set_state(renderer->pipeline, GST_STATE_PLAYING);
     renderer->base_time = GST_CLOCK_TIME_NONE;
     renderer->first_video_time = GST_CLOCK_TIME_NONE;
@@ -206,6 +216,9 @@ void mux_renderer_push_video(unsigned char *data, int data_len, uint64_t ntp_tim
 }
 
 void mux_renderer_push_audio(unsigned char *data, int data_len, uint64_t ntp_time) {
+    if (no_audio) {
+        return;
+    }
     if (!renderer || !renderer->pipeline || !renderer->audio_appsrc) return;
     
     if (!renderer->audio_started && renderer->first_video_time != GST_CLOCK_TIME_NONE) {
@@ -268,8 +281,10 @@ void mux_renderer_stop(void) {
     
     gst_object_unref(renderer->video_appsrc);
     renderer->video_appsrc = NULL;
-    gst_object_unref(renderer->audio_appsrc);
-    renderer->audio_appsrc = NULL;
+    if (!no_audio) {
+        gst_object_unref(renderer->audio_appsrc);
+        renderer->audio_appsrc = NULL;
+    }
     gst_object_unref(renderer->filesink);
     renderer->filesink = NULL;
     gst_object_unref(renderer->bus);

--- a/renderers/mux_renderer.h
+++ b/renderers/mux_renderer.h
@@ -29,7 +29,7 @@ extern "C" {
 #include <stdbool.h>
 #include "../lib/logger.h"
 
-void mux_renderer_init(logger_t *logger, const char *filename);
+  void mux_renderer_init(logger_t *logger, const char *filename, bool use_audio);
 void mux_renderer_choose_audio_codec(unsigned char audio_ct);
 void mux_renderer_choose_video_codec(bool is_h265);
 void mux_renderer_start(void);

--- a/uxplay.cpp
+++ b/uxplay.cpp
@@ -908,6 +908,7 @@ static void print_info (char *name) {
     printf("-n name   Specify network name of the AirPlay server (UTF-8/ascii)\n");
     printf("-nh       Do not add \"@hostname\" at the end of AirPlay server name\n");
     printf("-h265     Support h265 (4K) video (with h265 versions of h264 plugins)\n");
+    printf("-mp4 [fn] Record (non-hls) audio/video to mp4; default fn=\"recording\"\n");
     printf("-hls [v]  Support HTTP Live Streaming (HLS), Youtube app video only: \n");
     printf("          v = 2 or 3 (default 3) optionally selects video player version\n");
     printf("-lang xx  HLS language preferences (\"fr:es:..\", overrides $LANGUAGE)\n");
@@ -953,7 +954,6 @@ static void print_info (char *name) {
     printf("-vrtp pl  Use rtph26[4,5]pay to send decoded video elsewhere: \"pl\"\n");
     printf("          is the remaining pipeline, starting with rtph26*pay options:\n");
     printf("          e.g. \"config-interval=1 ! udpsink host=127.0.0.1 port=5000\"\n");
-    printf("-rtp [fn] Record audio and video to MP4 file; default fn=\"recording\"\n");
     printf("          Writes output to \"fn.N.mp4\"\n");
     printf("-v4l2     Use Video4Linux2 for GPU hardware h264 decoding\n");
     printf("-bt709    Sometimes needed for Raspberry Pi models using Video4Linux2 \n");
@@ -986,6 +986,9 @@ static void print_info (char *name) {
     printf("-key [fn] Store private key in $HOME/.uxplay.pem (or in file \"fn\")\n");
     printf("-dacp [fn]Export client DACP information to file $HOME/.uxplay.dacp\n");
     printf("          (option to use file \"fn\" instead); used for client remote\n");
+    printf("-ble [fn] For BluetoothLE beacon: write data to file ~/.uxplay.ble\n");
+    printf("          optional: write to file \"fn\" (\"fn\" = \"off\" to cancel)\n");
+    printf("-d [n]    Enable debug logging; optional: n=1 to skip normal packet data\n");
     printf("-vdmp [n] Dump h264 video output to \"fn.h264\"; fn=\"videodump\",change\n");
     printf("          with \"-vdmp [n] filename\". If [n] is given, file fn.x.h264\n");
     printf("          x=1,2,.. opens whenever a new SPS/PPS NAL arrives, and <=n\n");
@@ -994,9 +997,6 @@ static void print_info (char *name) {
     printf("          =1,2,..; fn=\"audiodump\"; change with \"-admp [n] filename\".\n");
     printf("          x increases when audio format changes. If n is given, <= n\n");
     printf("          audio packets are dumped. \"aud\"= unknown format.\n");
-    printf("-ble [fn] For BluetoothLE beacon: write data to file ~/.uxplay.ble\n");
-    printf("          optional: write to file \"fn\" (\"fn\" = \"off\" to cancel)\n");
-    printf("-d [n]    Enable debug logging; optional: n=1 to skip normal packet data\n");
     printf("-v        Displays version information\n");
     printf("-h        Displays this help\n");
     printf("-rc fn    Read startup options from file \"fn\" instead of ~/.uxplayrc, etc\n");
@@ -3087,7 +3087,7 @@ int main (int argc, char *argv[]) {
     }
 
     if (mux_to_file) {
-        mux_renderer_init(render_logger, mux_filename.c_str());
+        mux_renderer_init(render_logger, mux_filename.c_str(), use_audio);
     }
 
     if (udp[0]) {


### PR DESCRIPTION
-rtp now muxes video and audio streams into a single output MP4. Allows specification of a filename.

If audio or video format changes are detected, the pipeline will be regenerated and a new file will be created, with the numbering incremented.