### PR TITLE
Add -artp option for audio RTP output

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@
 -   option `-vrtp <rest-of-pipeline>`  bypasses rendering by UxPlay, and instead
     transmits rtp packets of decrypted h264 or h265 video to
     an external renderer (e.g. OBS Studio) at an address specified in `rest-of-pipeline`.
-    (Note: this is video only, an option "-rtp" which muxes audio and video into a mpeg4 container still needs to be created:
+    Similarly, `-artp <rest-of-pipeline>` forwards decoded audio as L16 RTP packets.
+    Both options can be used together to forward video and audio (as separate concurrent streams) to external applications.
+    (Note: an option "-rtp" which muxes audio and video into a mpeg4 container still needs to be created:
     Pull Requests welcomed).
     
 -   (for Linux/*BSD Desktop Environments using D-Bus). New option `-scrsv <n>` provides screensaver inhibition (e.g., to
@@ -1312,6 +1314,11 @@ superior-quality ALAC Apple Lossless audio in Airplay audio-only mode.
 Uses rtph264pay or rtph265pay as appropriate: *pipeline* should start with any
 rtph26xpay options (such as config_interval= or aggregate-mode =), followed by
 a sending method:  *e.g.*, `"config-interval=1 ! udpsink host=127.0.0.1 port=5000`".
+
+**-artp *pipeline***:  forward decoded audio as L16 RTP packets to somewhere else, without local playback.
+Uses rtpL16pay (16-bit signed big-endian PCM, 44100Hz stereo): *pipeline* should start with any
+rtpL16pay options (such as pt=), followed by a sending method:
+*e.g.*, `"pt=96 ! udpsink host=127.0.0.1 port=5002"`.  iOS volume control still works over RTP.
 
 **-v4l2** Video settings for hardware h264 video decoding in the GPU by
 Video4Linux2. Equivalent to `-vd v4l2h264dec -vc v4l2convert`.

--- a/renderers/audio_renderer.h
+++ b/renderers/audio_renderer.h
@@ -33,7 +33,7 @@ extern "C" {
 #include "../lib/logger.h"
 
 bool gstreamer_init();
-void audio_renderer_init(logger_t *logger, const char* audiosink, const bool *audio_sync, const bool *video_sync);
+void audio_renderer_init(logger_t *logger, const char* audiosink, const bool *audio_sync, const bool *video_sync, const char *artp_pipeline);
 void audio_renderer_start(unsigned char* compression_type);
 void audio_renderer_stop();
 void audio_renderer_render_buffer(unsigned char* data, int *data_len, unsigned short *seqnum, uint64_t *ntp_time);

--- a/uxplay.1
+++ b/uxplay.1
@@ -107,6 +107,12 @@ UxPlay 1.73: An open\-source AirPlay mirroring (+ audio streaming) server:
    is the remaining pipeline, starting with rtph26*pay options:
 .IP
    e.g. "config-interval=1 ! udpsink host=127.0.0.1 port=5000"
+.TP
+\fB\-artp\fI pl\fR  Use rtpL16pay to send decoded audio elsewhere: "pl"
+.IP
+   is the remaining pipeline, starting with rtpL16pay options:
+.IP
+   e.g. "pt=96 ! udpsink host=127.0.0.1 port=5002"
 .PP
 .TP
 \fB\-v4l2\fR     Use Video4Linux2 for GPU hardware h264 video decoding.


### PR DESCRIPTION
## Summary

Add a new `-artp` command-line option that routes decoded audio to an RTP stream instead of the local audio sink, following the existing `-vrtp` pattern for video.

**Usage example:**
```bash
uxplay -artp "pt=96 ! udpsink host=192.168.1.100 port=5002"
```

## Implementation Details

- Decodes audio (AAC-ELD/ALAC) to PCM as normal
- Converts to S16BE format required by `rtpL16pay`
- Preserves the `volume` element so iOS volume control still works over RTP
- Sends L16 RTP packets (16-bit signed big-endian, 44100Hz, stereo)

The resulting GStreamer pipeline for RTP mode:
```
appsrc ! queue ! avdec_aac ! audioconvert ! audioresample ! volume ! audioconvert ! audio/x-raw,format=S16BE,rate=44100,channels=2 ! rtpL16pay <user options>
```

## Use Case

This enables forwarding AirPlay audio to external applications or network destinations for further processing, similar to how `-vrtp` works for video.

Personally, I'm successfully using this branch's code to power an AirPlay bridge to stream video+audio to the Nintendo GameCube + Wii, and it's working well. (Repo will go live once it's more polished!) I transcode the video stream (with `vrtp`) to JPEG frames while transcoding its audio (with `artp`) to another format. Both are sent out in separate streams, under the rationale that video frames can drop occasionally while audio frames must not (or else horrible pops can happen).

This audio stream support was a significant enough need for my project that I went ahead and added it to UxPlay. But in order for others to use my AirPlay bridge, UxPlay itself will need this patch. I hope this will also help others use UxPlay in new/novel ways conducive to their own projects' goals too!

## Test plan

- [x] Build completes without errors
- [x] `-h` shows new `-artp` option with description
- [x] `-artp` without argument shows appropriate error message
- [x] Audio streams correctly to UDP receiver (tested with custom Python receiver and gst-launch-1.0)
- [x] Combined `-vrtp` and `-artp` work together
- [x] Normal audio output (without `-artp`) still works