### PR TITLE
Fix screensaver inhibition not working nicely when mirroring

### DIFF
--- a/README.html
+++ b/README.html
@@ -50,7 +50,7 @@ pipelines.</p></li>
 <li><p>(for Linux/*BSD Desktop Environments using D-Bus). New option
 <code>-scrsv &lt;n&gt;</code> provides screensaver inhibition (e.g., to
 prevent screensaver function while watching mirrored videos without
-keyboard or mouse activity): n = 0 (off) n=1 (on during video activity)
+keyboard or mouse activity): n = 0 (off) n=1 (on while streaming video)
 n=2 (always on while UxPlay is running). Tested on
 Gnome/KDE/Cinnamon/Mate/Xfce 4: may need adjustment for other Desktop
 Environments (please report). (watch output of <code>dbus-monitor</code>

--- a/README.txt
+++ b/README.txt
@@ -47,7 +47,7 @@
 -   (for Linux/\*BSD Desktop Environments using D-Bus). New option
     `-scrsv <n>` provides screensaver inhibition (e.g., to prevent
     screensaver function while watching mirrored videos without keyboard
-    or mouse activity): n = 0 (off) n=1 (on during video activity) n=2
+    or mouse activity): n = 0 (off) n=1 (on while streaming video) n=2
     (always on while UxPlay is running). Tested on
     Gnome/KDE/Cinnamon/Mate/Xfce 4: may need adjustment for other
     Desktop Environments (please report). (watch output of

--- a/lib/raop.h
+++ b/lib/raop.h
@@ -96,6 +96,7 @@ struct raop_callbacks_s {
     void  (*audio_get_format)(void *cls, unsigned char *ct, unsigned short *spf, bool *usingScreen, bool *isMedia, uint64_t *audioFormat);
     void  (*video_report_size)(void *cls, float *width_source, float *height_source, float *width, float *height);
     void  (*mirror_video_activity)(void *cls, double *txusage);
+    void  (*mirror_video_running)(void *cls, bool is_running);
     void  (*report_client_request) (void *cls, char *deviceid, char *model, char *name, bool *admit);
     void  (*display_pin) (void *cls, char * pin);
     void  (*register_client) (void *cls, const char *device_id, const char *pk_str, const char *name);

--- a/lib/raop_rtp_mirror.c
+++ b/lib/raop_rtp_mirror.c
@@ -847,6 +847,9 @@ raop_rtp_mirror_thread(void *arg)
     MUTEX_LOCK(raop_rtp_mirror->run_mutex);
     raop_rtp_mirror->running = false;
     MUTEX_UNLOCK(raop_rtp_mirror->run_mutex);
+    if (raop_rtp_mirror->callbacks.mirror_video_running) {
+        raop_rtp_mirror->callbacks.mirror_video_running(raop_rtp_mirror->callbacks.cls, false);
+    }
 
     logger_log(raop_rtp_mirror->logger, LOGGER_DEBUG, "raop_rtp_mirror exiting TCP thread");
     if (conn_reset&& raop_rtp_mirror->callbacks.conn_reset) {
@@ -925,6 +928,9 @@ raop_rtp_mirror_start(raop_rtp_mirror_t *raop_rtp_mirror, unsigned short *mirror
     /* Create the thread and initialize running values */
     raop_rtp_mirror->running = 1;
     raop_rtp_mirror->joined = 0;
+    if (raop_rtp_mirror->callbacks.mirror_video_running) {
+        raop_rtp_mirror->callbacks.mirror_video_running(raop_rtp_mirror->callbacks.cls, true);
+    }
 
     THREAD_CREATE(raop_rtp_mirror->thread_mirror, raop_rtp_mirror_thread, raop_rtp_mirror);
     MUTEX_UNLOCK(raop_rtp_mirror->run_mutex);

--- a/uxplay.1
+++ b/uxplay.1
@@ -27,7 +27,7 @@ UxPlay 1.73.6: An open\-source AirPlay mirroring (+ audio streaming) server:
 .TP
 \fB\-lang\fR    (or -lang 0): play undubbed HLS version (overrides $LANGUAGE)
 .TP
-\fB\-scrsv\fI n\fR  Screensaver override \fIn\fR:0=off 1=on during activity 2=always on.  
+\fB\-scrsv\fI n\fR  Screensaver override \fIn\fR:0=off 1=on while streaming video 2=always on.
 .TP
 \fB\-pin\fI[xxxx]\fRUse a 4-digit pin code to control client access (default: no)
 .IP

--- a/uxplay.cpp
+++ b/uxplay.cpp
@@ -223,8 +223,6 @@ static const char *reason_always = "mirroring client: inhibit always";
 static const char *reason_active = "actively receiving video";
 static int activity_count;
 static float previous_hls_position = 0.0f;
-static double activity_threshold = 500000.0;  // threshold for FPSdata item txUsageAvg to classify mirror video as "active"
-#define MAX_ACTIVITY_COUNT 60
 #endif
 
 /* logging */
@@ -922,7 +920,7 @@ static void print_info (char *name) {
     printf("          v = 2 or 3 (default 3) optionally selects video player version\n");
     printf("-lang xx  HLS language preferences (\"fr:es:..\", overrides $LANGUAGE)\n");
     printf("-lang     (or -lang 0): play undubbed HLS version (overrides $LANGUAGE)\n");
-    printf("-scrsv n  Screensaver override n: 0=off 1=on during activity 2=always on\n");
+    printf("-scrsv n  Screensaver override n: 0=off 1=on while streaming video 2=always on\n");
     printf("-pin[xxxx]Use a 4-digit pin code to control client access (default: no)\n");
     printf("          default pin is random: optionally use fixed pin xxxx\n");
     printf("-reg [fn] Keep a register in $HOME/.uxplay.register to verify returning\n");
@@ -2357,23 +2355,11 @@ extern "C" void video_process (void *cls, raop_ntp_t *ntp, video_decode_struct *
 }
 
 #ifdef DBUS
-extern "C" void mirror_video_activity  (void *cls, double *txusage) {
+extern "C" void mirror_video_running  (void *cls, bool is_running) {
     if (scrsv != 1) {
         return;
     }
-    if (*txusage > activity_threshold) {
-        if (activity_count < MAX_ACTIVITY_COUNT) {
-            activity_count++;
-        } else if (activity_count == MAX_ACTIVITY_COUNT  && !dbus_last_message) {
-	    dbus_screensaver_inhibiter(true);
-        }
-    } else {
-      if (activity_count > 0) {
-          activity_count--;
-      } else if (activity_count == 0 && dbus_last_message) {
-          dbus_screensaver_inhibiter(false);
-      }
-    }
+    dbus_screensaver_inhibiter(is_running);
 }
 #endif
 
@@ -2726,7 +2712,7 @@ static int start_raop_server (unsigned short display[5], unsigned short tcp[3], 
     raop_cbs.video_reset = video_reset;
     raop_cbs.video_set_codec = video_set_codec;
 #ifdef DBUS
-    raop_cbs.mirror_video_activity = mirror_video_activity;
+    raop_cbs.mirror_video_running = mirror_video_running;
 #endif
     raop_cbs.on_video_play = on_video_play;
     raop_cbs.on_video_scrub = on_video_scrub;
@@ -3007,7 +2993,7 @@ int main (int argc, char *argv[]) {
         }
 
         LOGI("Will attempt to use %s (D-Bus screensaver inhibition) %s", dbus_service.c_str(),
-             (scrsv == 1 ? "only during screen activity" : "always"));
+             (scrsv == 1 ? "only while streaming video" : "always"));
         if (scrsv == 2) {
             dbus_screensaver_inhibiter(true);
         }


### PR DESCRIPTION
This changes the behavior to inhibit the screen from going to sleep as long as the video stream is still running.

The reason for this change is that I couldn't really get the old activity based method to work nicely on the different devices I tried it out with. The old method almost never had the inhibitor kick in even if I was actively using the device I was mirroring from.

The issues were three fold:
1. Because of the activity counter, it was really hard to get it to kick in unless large parts of the screen was constantly moving around. (I tested with an Ipad and some Mac Books)
2. Even if there was lots of constant activity, the sleep inhibitor would take longer than a minute to kick in as I would get tx usage reports callbacks every 2-3 seconds. So even with activity, it could take more than two minutes for it to kick in. (Which would lead to the host system dimming/turning off the screen even if a mirror session just had started)
3. If the video mirroring session was stopped while the inhibitor was on, it wouldn't get disabled as no more calls to `mirror_video_activity` would be made.

To solve this, I think it is better to actively inhibit the screen from going to sleep while mirroring/streaming video. I don't think looking at the amount of data transferred is going to work nicely as that can vary wildly depending on what is being streamed and how well the video updates can be compressed.

At least it failed more times that it actually worked for me when trying to do presentations or just navigating in a file browser for example.

I've tested out these changes on my end and they seem to work nicely and is now very consistent. IE, if there is video being mirrored, the machine will not go to sleep.

Of course this makes it not activity based anymore, but at least to me, it makes it much less error prone as I couldn't really get the old method to work for me consistently.