### PR TITLE
Alternate Systemd Files for BLE: Activation Timer and Parallel Uxplay Beacon Service 

### DIFF
--- a/uxplay_ble_service/uxplay-beacon.service
+++ b/uxplay_ble_service/uxplay-beacon.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=BLE Advertising Beacon script for AirPlay Unix mirroring server uxplay (uxplay.service)
+
+Requisite=uxplay.service
+After=uxplay.service
+
+[Service]
+Type=simple
+ExecStart=uxplay-beacon.py
+
+## consider switching to -u ExecStart if you wish to see the output from the script
+#ExecStart=python -u /usr/local/bin/uxplay-beacon.py
+
+
+
+

--- a/uxplay_ble_service/uxplay.service
+++ b/uxplay_ble_service/uxplay.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=AirPlay Unix mirroring server
+
+Upholds=uxplay-beacon.service
+PropagatesStopTo=uxplay-beacon.service
+
+
+[Service]
+Type=simple
+ExecStart=uxplay
+
+Restart=always
+#Restart=on-failure
+
+#StandardOutput=file:%h/uxplay.log
+

--- a/uxplay_ble_service/uxplay.timer
+++ b/uxplay_ble_service/uxplay.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Timer that initially starts uxplay.service
+
+[Timer]
+OnStartupSec=30
+Unit=uxplay.service
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
# Alternate systemd files for BLE only mode

I wanted to run uxplay automatically, without relying on mDNS at all - i am very happy about the BLE feature!

This PR shows an alternate set of systemd files that allows uxplay to startup automatically, without relying on avahi to be present, via a timer.
In addition the uxplay-beacon script is configured to always run in parallel to uxplay.

## Changes made

The uxplay.service file by @Deuchnord was used as a starting point. 

To run uxplay independent of the avahi-daemon i decided to use a timer instead.
This is the new **uxplay.timer** file.
It simply activates the **uxplay.service** after some time.
I currently have this set to 30 seconds, which is a lot and can definitely be optimized - however uxplay cannot run immediately as this will mess with startup & the time may vary for different setups, so i felt it better to be safe.

In the new **uxplay.service** file dependencies to avahi and the install section have been removed. 
A dependency to the new **uxplay-beacon.service** has been added. 

The **uxplay-beacon.service** automatically starts the uxplay BLE script, which manages the BLE advertising that replaces the mDNS discovery.
The **uxplay.service** and **uxplay-beacon.service** have been configured so that the **uxplay-beacon.service** essentially follows all start, stops and restarts from the **uxplay.service**.
While this may be a little overcautious it allows smooth operation even if uxplay crashes in unexpected ways, as the BLE script is restarted alongside uxplay.
 

## Usage

As with the previous systemd file, all files are placed in the `systemd/user` directory. 
They should then be enabled.

```
systemctl --user enable uxplay.service
systemctl --user enable uxplay-beacon.service
systemctl --user enable uxplay.timer
```

Uxplay should also be configured to use the BLE advertising - this can be done via uxplay's config file.

At this point uxplay starts automatically after startups (plus some delay from the timer).
The setup can also be triggered manually, with the same command as the previous non-BLE service setup (with no delay). 
```
systemctl --user start uxplay
```