### PR TITLE
refactor dnssd.c  (in preparation for an alternative implementation)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,12 @@ add_subdirectory( lib/playfair )
 add_subdirectory( lib )
 add_subdirectory( renderers )
 
+set (USE_DNS_SD TRUE)
+if (USE_DNS_SD)
+  add_subdirectory( lib/dns_sd)
+endif()
+
+
 if  ( GST_MACOS )
      add_definitions( -DGST_MACOS )
      message ( STATUS "define GST_MACOS" )

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,5 +1,11 @@
 include_directories( playfair llhttp )
 
+
+if (USE_DNS_SD )
+  message( STATUS "******** Compiling to use  BonJour/DNS_SD" )
+  include_directories( dns_sd )
+endif()
+
 message( STATUS "*** CFLAGS \"" ${CMAKE_C_FLAGS} "\" from build environment will be postpended to CMAKE_CFLAGS" )
 
 # Common x86/x86_64 cflags
@@ -64,11 +70,13 @@ if ( APPLE )
   target_link_libraries( airplay 
                          pthread
                          playfair
+                         dnssd
                          llhttp )
 elseif( WIN32 )
   target_link_libraries( airplay 
                          pthread
                          playfair
+                         dnssd
                          llhttp
                          wsock32
 			 iphlpapi
@@ -77,6 +85,7 @@ else()
   target_link_libraries( airplay PUBLIC
           pthread
           playfair
+          dnssd
           llhttp )
 endif()
 
@@ -140,41 +149,3 @@ else()
   target_compile_definitions( airplay PUBLIC OPENSSL_API_COMPAT=0x10101000L )
   target_link_libraries( airplay PUBLIC OpenSSL::Crypto )
 endif()
-
-#dns_sd 
-if ( NOT APPLE )
-  pkg_search_module(AVAHI_DNSSD avahi-compat-libdns_sd)
-  if (AVAHI_DNSSD_FOUND)
-    target_include_directories( airplay PRIVATE ${AVAHI_DNSSD_INCLUDE_DIRS} )
-    find_library( DNSSD ${AVAHI_DNSSD_LIBRARIES} PATH ${AVAHI_DNSSD_LIBDIR})
-    target_link_libraries(airplay PUBLIC ${DNSSD} )
-  else()  # can also build if mDNSResponder or another implementation of dns_sd is present instead of Avahi
-    if ( WIN32 )
-      if (DEFINED ENV{BONJOUR_SDK_HOME}) 
-        set(BONJOUR_SDK "$ENV{BONJOUR_SDK_HOME}" )
-      else()
-        set(BONJOUR_SDK "C:\\Program Files\\Bonjour SDK")
-      endif()
-      message( STATUS "BONJOUR_SDK_HOME " ${BONJOUR_SDK} )
-      set(DNSSD "${BONJOUR_SDK}/Lib/x64/dnssd.lib")
-      target_link_libraries(airplay ${DNSSD} )
-      message( STATUS "dns_sd: using " ${DNSSD} )
-      find_path(DNSSD_INCLUDE_DIR dns_sd.h HINTS ${BONJOUR_SDK}/Include )
-    else()
-      find_library( DNSSD dns_sd )
-      if( NOT DNSSD )
-        message( FATAL_ERROR "libdns_sd missing; can be provided by avahi_compat-libdns_sd or mDNSResponder." )
-      else()
-        message( STATUS "dns_sd:  found" ${DNSSD} )
-      endif()
-      target_link_libraries(airplay PUBLIC ${DNSSD} ) 
-      find_path(DNSSD_INCLUDE_DIR dns_sd.h HINTS ${CMAKE_INSTALL_INCLUDEDIR} )
-    endif()
-    if ( NOT DNSSD_INCLUDE_DIR )
-       message( FATAL_ERROR " dns_sd.h not found ")
-     else()
-        message( STATUS "found dns_sd.h in " ${DNSSD_INCLUDE_DIR} )
-     endif()
-    target_include_directories( airplay PRIVATE ${DNSSD_INCLUDE_DIR} )
-  endif()
-endif()	

--- a/lib/dns_sd/CMakeLists.txt
+++ b/lib/dns_sd/CMakeLists.txt
@@ -1,0 +1,48 @@
+aux_source_directory(. dnssd_src)
+set(DIR_SRCS ${dnssd_src})
+include_directories(.)
+add_library( dnssd 
+        STATIC
+        ${DIR_SRCS})
+
+find_package(PkgConfig REQUIRED)
+
+#dns_sd 
+if ( NOT APPLE )
+  pkg_search_module(AVAHI_DNSSD avahi-compat-libdns_sd)
+  if (AVAHI_DNSSD_FOUND)
+    target_include_directories(dnssd PRIVATE ${AVAHI_DNSSD_INCLUDE_DIRS} )
+    find_library( DNSSD ${AVAHI_DNSSD_LIBRARIES} PATH ${AVAHI_DNSSD_LIBDIR})
+    target_link_libraries(dnssd PUBLIC ${DNSSD} )
+  else()  # can also build if mDNSResponder or another implementation of dns_sd is present instead of Avahi
+    if ( WIN32 )
+      if (DEFINED ENV{BONJOUR_SDK_HOME}) 
+        set(BONJOUR_SDK "$ENV{BONJOUR_SDK_HOME}" )
+      else()
+        set(BONJOUR_SDK "C:\\Program Files\\Bonjour SDK")
+      endif()
+      message( STATUS "BONJOUR_SDK_HOME " ${BONJOUR_SDK} )
+      set(DNSSD "${BONJOUR_SDK}/Lib/x64/dnssd.lib")
+      target_link_libraries(dnssd ${DNSSD} )
+      message( STATUS "dns_sd: using " ${DNSSD} )
+      find_path(DNSSD_INCLUDE_DIR dns_sd.h HINTS ${BONJOUR_SDK}/Include )
+    else()
+      find_library( DNSSD dns_sd )
+      if( NOT DNSSD )
+        message( FATAL_ERROR "libdns_sd missing; can be provided by avahi_compat-libdns_sd or mDNSResponder." )
+      else()
+        message( STATUS "dns_sd:  found" ${DNSSD} )
+      endif()
+      target_link_libraries(dnssd PUBLIC ${DNSSD} ) 
+      find_path(DNSSD_INCLUDE_DIR dns_sd.h HINTS ${CMAKE_INSTALL_INCLUDEDIR} )
+    endif()
+    if ( NOT DNSSD_INCLUDE_DIR )
+       message( FATAL_ERROR " dns_sd.h not found ")
+     else()
+        message( STATUS "found dns_sd.h in " ${DNSSD_INCLUDE_DIR} )
+     endif()
+    target_include_directories(dnssd PRIVATE ${DNSSD_INCLUDE_DIR} )
+  endif()
+endif()	
+
+

--- a/lib/dns_sd/dns_sd.c
+++ b/lib/dns_sd/dns_sd.c
@@ -402,3 +402,18 @@ dnssd_unregister_airplay(dnssd_t *dnssd_public)
     dnssd->DNSServiceRefDeallocate(dnssd->airplay_service);
     dnssd->airplay_service = NULL;
 }
+
+void dnssd_error_text(int *dnssd_error, const char *appname) {
+    printf("*** dnssd_implementation: external, dns_sd.h\n");
+    if (*dnssd_error == -65537) {
+        printf("    No DNS-SD Server found (DNSServiceRegister call returned kDNSServiceErr_Unknown)\n");
+    } else if (*dnssd_error == -65548) {
+        printf("    DNSServiceRegister call returned kDNSServiceErr_NameConflict\n");
+        printf("    Is another instance of %s running with the same DeviceID (MAC address) or using same network ports?\n",
+	        appname);
+        printf("    Use options -m ... and -p ... to allow multiple instances of %s to run concurrently\n", appname); 
+    } else {
+        printf("    mDNS Error codes are in range FFFE FF00 (-65792) to FFFE FFFF (-65537) "
+	       "(see Apple's dns_sd.h)\n", *dnssd_error);
+    }
+}

--- a/lib/dns_sd/dns_sd.c
+++ b/lib/dns_sd/dns_sd.c
@@ -1,0 +1,404 @@
+/**
+ *  Copyright (C) 2011-2012  Juho Vähä-Herttua
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *=================================================================
+ * modified by fduncanh 2022, 2026
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include <assert.h>
+
+#include "../compat.h"
+#include <dns_sd.h>
+#include "../dnssd.h"
+#include "../dnssdint.h"
+#include "../utils.h"
+
+#define MAX_DEVICEID 18
+#define MAX_SERVNAME 256
+
+#if defined(HAVE_LIBDL) && !defined(__APPLE__)
+# define USE_LIBDL 1
+#else
+# define USE_LIBDL 0
+#endif
+
+#if defined(_WIN32) || USE_LIBDL
+# ifdef _WIN32
+#  include <stdint.h>
+#  if !defined(EFI32) && !defined(EFI64)
+#   define DNSSD_STDCALL __stdcall
+#  else
+#   define DNSSD_STDCALL
+#  endif
+# else
+#  include <dlfcn.h>
+#  define DNSSD_STDCALL
+# endif
+
+typedef struct _DNSServiceRef_t *DNSServiceRef;
+#ifndef _WIN32
+typedef union _TXTRecordRef_t { char PrivateData[16]; char *ForceNaturalAlignment; } TXTRecordRef;
+#endif
+typedef uint32_t DNSServiceFlags;
+typedef int32_t  DNSServiceErrorType;
+
+typedef void (DNSSD_STDCALL *DNSServiceRegisterReply)
+    (
+    DNSServiceRef                       sdRef,
+    DNSServiceFlags                     flags,
+    DNSServiceErrorType                 errorCode,
+    const char                          *name,
+    const char                          *regtype,
+    const char                          *domain,
+    void                                *context
+    );
+
+#else
+//# include <dns_sd.h>
+# define DNSSD_STDCALL
+#endif
+
+typedef DNSServiceErrorType (DNSSD_STDCALL *DNSServiceRegister_t)
+        (
+                DNSServiceRef                       *sdRef,
+                DNSServiceFlags                     flags,
+                uint32_t                            interfaceIndex,
+                const char                          *name,
+                const char                          *regtype,
+                const char                          *domain,
+                const char                          *host,
+                uint16_t                            port,
+                uint16_t                            txtLen,
+                const void                          *txtRecord,
+                DNSServiceRegisterReply             callBack,
+                void                                *context
+        );
+typedef void (DNSSD_STDCALL *DNSServiceRefDeallocate_t)(DNSServiceRef sdRef);
+typedef void (DNSSD_STDCALL *TXTRecordCreate_t)
+        (
+                TXTRecordRef     *txtRecord,
+                uint16_t         bufferLen,
+                void             *buffer
+        );
+typedef void (DNSSD_STDCALL *TXTRecordDeallocate_t)(TXTRecordRef *txtRecord);
+typedef DNSServiceErrorType (DNSSD_STDCALL *TXTRecordSetValue_t)
+        (
+                TXTRecordRef     *txtRecord,
+                const char       *key,
+                uint8_t          valueSize,
+                const void       *value
+        );
+typedef uint16_t (DNSSD_STDCALL *TXTRecordGetLength_t)(const TXTRecordRef *txtRecord);
+typedef const void * (DNSSD_STDCALL *TXTRecordGetBytesPtr_t)(const TXTRecordRef *txtRecord);
+
+
+typedef struct dnssd_private_s {
+#ifdef WIN32
+    HMODULE module;
+#elif USE_LIBDL
+    void *module;
+#endif
+
+    DNSServiceRegister_t       DNSServiceRegister;
+    DNSServiceRefDeallocate_t  DNSServiceRefDeallocate;
+    TXTRecordCreate_t          TXTRecordCreate;
+    TXTRecordSetValue_t        TXTRecordSetValue;
+    TXTRecordGetLength_t       TXTRecordGetLength;
+    TXTRecordGetBytesPtr_t     TXTRecordGetBytesPtr;
+    TXTRecordDeallocate_t      TXTRecordDeallocate;
+
+    TXTRecordRef raop_record;
+    TXTRecordRef airplay_record;
+
+    DNSServiceRef raop_service;
+    DNSServiceRef airplay_service;
+
+} dnssd_private_t;
+
+void *
+dnssd_private_init(dnssd_t *dnssd_public, int *error)
+{
+    if (error) *error = DNSSD_ERROR_NOERROR;
+
+    dnssd_private_t *dnssd = (dnssd_private_t *) calloc(1, sizeof(dnssd_private_t));
+    if (!dnssd) {
+        if (error) *error = DNSSD_ERROR_OUTOFMEM;
+        return NULL;
+    }
+
+#ifdef WIN32
+    dnssd->module = LoadLibraryA("dnssd.dll");
+    if (!dnssd->module) {
+        if (error) *error = DNSSD_ERROR_LIBNOTFOUND;
+        free(dnssd);
+        return NULL;
+    }
+    dnssd->DNSServiceRegister = (DNSServiceRegister_t)GetProcAddress(dnssd->module, "DNSServiceRegister");
+    dnssd->DNSServiceRefDeallocate = (DNSServiceRefDeallocate_t)GetProcAddress(dnssd->module, "DNSServiceRefDeallocate");
+    dnssd->TXTRecordCreate = (TXTRecordCreate_t)GetProcAddress(dnssd->module, "TXTRecordCreate");
+    dnssd->TXTRecordSetValue = (TXTRecordSetValue_t)GetProcAddress(dnssd->module, "TXTRecordSetValue");
+    dnssd->TXTRecordGetLength = (TXTRecordGetLength_t)GetProcAddress(dnssd->module, "TXTRecordGetLength");
+    dnssd->TXTRecordGetBytesPtr = (TXTRecordGetBytesPtr_t)GetProcAddress(dnssd->module, "TXTRecordGetBytesPtr");
+    dnssd->TXTRecordDeallocate = (TXTRecordDeallocate_t)GetProcAddress(dnssd->module, "TXTRecordDeallocate");
+
+    if (!dnssd->DNSServiceRegister || !dnssd->DNSServiceRefDeallocate || !dnssd->TXTRecordCreate ||
+        !dnssd->TXTRecordSetValue || !dnssd->TXTRecordGetLength || !dnssd->TXTRecordGetBytesPtr ||
+        !dnssd->TXTRecordDeallocate) {
+        if (error) *error = DNSSD_ERROR_PROCNOTFOUND;
+        FreeLibrary(dnssd->module);
+        free(dnssd);
+        return NULL;
+    }
+#elif USE_LIBDL
+    dnssd->module = dlopen("libdns_sd.so", RTLD_LAZY);
+    if (!dnssd->module) {
+      if (error) *error = DNSSD_ERROR_LIBNOTFOUND;
+      free(dnssd);
+      return NULL;
+    }
+    dnssd->DNSServiceRegister = (DNSServiceRegister_t)dlsym(dnssd->module, "DNSServiceRegister");
+    dnssd->DNSServiceRefDeallocate = (DNSServiceRefDeallocate_t)dlsym(dnssd->module, "DNSServiceRefDeallocate");
+    dnssd->TXTRecordCreate = (TXTRecordCreate_t)dlsym(dnssd->module, "TXTRecordCreate");
+    dnssd->TXTRecordSetValue = (TXTRecordSetValue_t)dlsym(dnssd->module, "TXTRecordSetValue");
+    dnssd->TXTRecordGetLength = (TXTRecordGetLength_t)dlsym(dnssd->module, "TXTRecordGetLength");
+    dnssd->TXTRecordGetBytesPtr = (TXTRecordGetBytesPtr_t)dlsym(dnssd->module, "TXTRecordGetBytesPtr");
+    dnssd->TXTRecordDeallocate = (TXTRecordDeallocate_t)dlsym(dnssd->module, "TXTRecordDeallocate");
+
+    if (!dnssd->DNSServiceRegister || !dnssd->DNSServiceRefDeallocate || !dnssd->TXTRecordCreate ||
+        !dnssd->TXTRecordSetValue || !dnssd->TXTRecordGetLength || !dnssd->TXTRecordGetBytesPtr ||
+        !dnssd->TXTRecordDeallocate) {
+        if (error) *error = DNSSD_ERROR_PROCNOTFOUND;
+        dlclose(dnssd->module);
+        free(dnssd);
+        return NULL;
+    }
+#else
+    dnssd->DNSServiceRegister = &DNSServiceRegister;
+    dnssd->DNSServiceRefDeallocate = &DNSServiceRefDeallocate;
+    dnssd->TXTRecordCreate = &TXTRecordCreate;
+    dnssd->TXTRecordSetValue = &TXTRecordSetValue;
+    dnssd->TXTRecordGetLength = &TXTRecordGetLength;
+    dnssd->TXTRecordGetBytesPtr = &TXTRecordGetBytesPtr;
+    dnssd->TXTRecordDeallocate = &TXTRecordDeallocate;
+#endif
+
+    return (void *) dnssd;
+}
+
+void
+dnssd_private_destroy(void *private)
+{
+    if (private) {
+        dnssd_private_t *dnssd = (dnssd_private_t *) private;
+#ifdef WIN32
+        FreeLibrary(dnssd->module);
+#elif USE_LIBDL
+        dlclose(dnssd->module);
+#endif
+        free(dnssd);
+    }
+}
+
+int
+dnssd_register_raop(dnssd_t *dnssd_public, unsigned short port)
+{
+    char servname[MAX_SERVNAME];
+
+    char features[22] = {0};
+
+    assert(dnssd_public);
+    assert(dnssd_public->dnssd_private);
+    dnssd_private_t *dnssd = (dnssd_private_t *) dnssd_public->dnssd_private;    
+
+    snprintf(features, sizeof(features), "0x%X,0x%X", dnssd_public->features1, dnssd_public->features2);
+
+    dnssd->TXTRecordCreate(&dnssd->raop_record, 0, NULL);
+    dnssd->TXTRecordSetValue(&dnssd->raop_record, "ch", strlen(RAOP_CH), RAOP_CH);
+    dnssd->TXTRecordSetValue(&dnssd->raop_record, "cn", strlen(RAOP_CN), RAOP_CN);
+    dnssd->TXTRecordSetValue(&dnssd->raop_record, "da", strlen(RAOP_DA), RAOP_DA);
+    dnssd->TXTRecordSetValue(&dnssd->raop_record, "et", strlen(RAOP_ET), RAOP_ET);
+    dnssd->TXTRecordSetValue(&dnssd->raop_record, "vv", strlen(RAOP_VV), RAOP_VV);
+    dnssd->TXTRecordSetValue(&dnssd->raop_record, "ft", strlen(features), features);
+    dnssd->TXTRecordSetValue(&dnssd->raop_record, "am", strlen(GLOBAL_MODEL), GLOBAL_MODEL);
+    dnssd->TXTRecordSetValue(&dnssd->raop_record, "md", strlen(RAOP_MD), RAOP_MD);
+    dnssd->TXTRecordSetValue(&dnssd->raop_record, "rhd", strlen(RAOP_RHD), RAOP_RHD);
+    switch (dnssd_public->pin_pw) {
+    case 1:
+        /* sf bit 3 0x08  means "pin required" according to https://openairplay.github.io/airplay-spec/status_flags.html  */
+        dnssd->TXTRecordSetValue(&dnssd->raop_record, "pw", strlen("true"), "true");
+        dnssd->TXTRecordSetValue(&dnssd->raop_record, "sf", strlen("0x8c"), "0x8c");
+        break;
+    case 2:
+    case 3:
+        /* sf bit 7 0x80 means "password required" according to https://openairplay.github.io/airplay-spec/status_flags.html  */
+        dnssd->TXTRecordSetValue(&dnssd->raop_record, "pw", strlen("true"), "true");
+        dnssd->TXTRecordSetValue(&dnssd->raop_record, "sf", strlen("0x84"), "0x84");
+        break;
+    default:
+        dnssd->TXTRecordSetValue(&dnssd->raop_record, "pw", strlen("false"), "false");
+        dnssd->TXTRecordSetValue(&dnssd->raop_record, "sf", strlen(RAOP_SF), RAOP_SF);
+        break;
+    }
+    dnssd->TXTRecordSetValue(&dnssd->raop_record, "sr", strlen(RAOP_SR), RAOP_SR);
+    dnssd->TXTRecordSetValue(&dnssd->raop_record, "ss", strlen(RAOP_SS), RAOP_SS);
+    dnssd->TXTRecordSetValue(&dnssd->raop_record, "sv", strlen(RAOP_SV), RAOP_SV);
+    dnssd->TXTRecordSetValue(&dnssd->raop_record, "tp", strlen(RAOP_TP), RAOP_TP);
+    dnssd->TXTRecordSetValue(&dnssd->raop_record, "txtvers", strlen(RAOP_TXTVERS), RAOP_TXTVERS);
+    dnssd->TXTRecordSetValue(&dnssd->raop_record, "vs", strlen(RAOP_VS), RAOP_VS);
+    dnssd->TXTRecordSetValue(&dnssd->raop_record, "vn", strlen(RAOP_VN), RAOP_VN);
+    dnssd->TXTRecordSetValue(&dnssd->raop_record, "pk", strlen(dnssd_public->pk), dnssd_public->pk);
+
+    /* Convert hardware address to string */
+    if (utils_hwaddr_raop(servname, sizeof(servname), dnssd_public->hw_addr, dnssd_public->hw_addr_len) < 0) {
+        /* FIXME: handle better */
+        return -1;
+    }
+
+    /* Check that we have bytes for 'hw@name' format */
+    if (sizeof(servname) < strlen(servname) + 1 + dnssd_public->name_len + 1) {
+        /* FIXME: handle better */
+        return -2;
+    }
+
+    strncat(servname, "@", sizeof(servname)-strlen(servname)-1);
+    strncat(servname, dnssd_public->name, sizeof(servname)-strlen(servname)-1);
+
+    /* Register the service */
+    DNSServiceErrorType retval = dnssd->DNSServiceRegister(&dnssd->raop_service, 0, 0,
+                                                          servname, "_raop._tcp",
+                                                          NULL, NULL,
+                                                          htons(port),
+                                                          dnssd->TXTRecordGetLength(&dnssd->raop_record),
+                                                          dnssd->TXTRecordGetBytesPtr(&dnssd->raop_record),
+                                                          NULL, NULL);
+
+    return (int) retval;   /* error codes are listed in Apple's dns_sd.h */
+}
+
+int
+dnssd_register_airplay(dnssd_t *dnssd_public, unsigned short port)
+{
+    char device_id[3 * MAX_HWADDR_LEN];
+    char features[22] = {0};
+
+    assert(dnssd_public);
+    assert(dnssd_public->dnssd_private);
+    dnssd_private_t *dnssd = (dnssd_private_t *) dnssd_public->dnssd_private;    
+    
+    snprintf(features, sizeof(features), "0x%X,0x%X", dnssd_public->features1, dnssd_public->features2);
+
+    /* Convert hardware address to string */
+    if (utils_hwaddr_airplay(device_id, sizeof(device_id), dnssd_public->hw_addr, dnssd_public->hw_addr_len) < 0) {
+        /* FIXME: handle better */
+        return -1;
+    }
+
+    // flags is a string representing a 20-bit flag (up to 3 hex digits)
+    dnssd->TXTRecordCreate(&dnssd->airplay_record, 0, NULL);
+    dnssd->TXTRecordSetValue(&dnssd->airplay_record, "deviceid", strlen(device_id), device_id);
+    dnssd->TXTRecordSetValue(&dnssd->airplay_record, "features", strlen(features), features);
+    switch (dnssd_public->pin_pw) {
+    case 1:   // display onscreen pin
+        dnssd->TXTRecordSetValue(&dnssd->airplay_record, "pw", strlen("true"), "true");
+        dnssd->TXTRecordSetValue(&dnssd->airplay_record, "flags", 3, "0x4");
+        break;  
+    case 2:  // require password
+    case 3:
+        dnssd->TXTRecordSetValue(&dnssd->airplay_record, "pw", strlen("true"), "true");
+        dnssd->TXTRecordSetValue(&dnssd->airplay_record, "flags", 3, "0x4");
+        break;
+    default:
+        dnssd->TXTRecordSetValue(&dnssd->airplay_record, "pw", strlen("false"), "false");
+        dnssd->TXTRecordSetValue(&dnssd->airplay_record, "flags", 3, "0x4");
+        break;
+    }
+    dnssd->TXTRecordSetValue(&dnssd->airplay_record, "model", strlen(GLOBAL_MODEL), GLOBAL_MODEL);
+    dnssd->TXTRecordSetValue(&dnssd->airplay_record, "pk", strlen(dnssd_public->pk), dnssd_public->pk);
+    dnssd->TXTRecordSetValue(&dnssd->airplay_record, "pi", strlen(AIRPLAY_PI), AIRPLAY_PI);
+    dnssd->TXTRecordSetValue(&dnssd->airplay_record, "srcvers", strlen(AIRPLAY_SRCVERS), AIRPLAY_SRCVERS);
+    dnssd->TXTRecordSetValue(&dnssd->airplay_record, "vv", strlen(AIRPLAY_VV), AIRPLAY_VV);
+
+    /* Register the service */
+    DNSServiceErrorType retval = dnssd->DNSServiceRegister(&dnssd->airplay_service, 0, 0,
+                                                           dnssd_public->name, "_airplay._tcp",
+                                                           NULL, NULL,
+                                                           htons(port),
+                                                           dnssd->TXTRecordGetLength(&dnssd->airplay_record),
+                                                           dnssd->TXTRecordGetBytesPtr(&dnssd->airplay_record),
+                                                           NULL, NULL);
+
+    return (int) retval;   /* error codes are listed in Apple's dns_sd.h */
+}
+
+const char *
+dnssd_get_raop_txt(dnssd_t *dnssd_public, int *length)
+{
+    assert(dnssd_public);
+    assert(dnssd_public->dnssd_private);
+    dnssd_private_t *dnssd = (dnssd_private_t *) dnssd_public->dnssd_private;    
+    assert(length);
+
+    *length = dnssd->TXTRecordGetLength(&dnssd->raop_record);
+    return dnssd->TXTRecordGetBytesPtr(&dnssd->raop_record);
+}
+
+const char *
+dnssd_get_airplay_txt(dnssd_t *dnssd_public, int *length)
+{
+    assert(dnssd_public);
+    assert(dnssd_public->dnssd_private);
+    dnssd_private_t *dnssd = (dnssd_private_t *) dnssd_public->dnssd_private;    
+    assert(length);
+
+    *length = dnssd->TXTRecordGetLength(&dnssd->airplay_record);
+    return dnssd->TXTRecordGetBytesPtr(&dnssd->airplay_record);
+}
+
+void
+dnssd_unregister_raop(dnssd_t *dnssd_public)
+{
+    assert(dnssd_public);
+    assert(dnssd_public->dnssd_private);
+    dnssd_private_t *dnssd = (dnssd_private_t *) dnssd_public->dnssd_private;    
+
+    if (!dnssd->raop_service) {
+        return;
+    }
+
+    /* Deallocate TXT record */
+    dnssd->TXTRecordDeallocate(&dnssd->raop_record);
+
+    dnssd->DNSServiceRefDeallocate(dnssd->raop_service);
+    dnssd->raop_service = NULL;
+}
+
+void
+dnssd_unregister_airplay(dnssd_t *dnssd_public)
+{
+    assert(dnssd_public);
+    assert(dnssd_public->dnssd_private);
+    dnssd_private_t *dnssd = (dnssd_private_t *) dnssd_public->dnssd_private;    
+
+    if (!dnssd->airplay_service) {
+        return;
+    }
+
+    /* Deallocate TXT record */
+    dnssd->TXTRecordDeallocate(&dnssd->airplay_record);
+
+    dnssd->DNSServiceRefDeallocate(dnssd->airplay_service);
+    dnssd->airplay_service = NULL;
+}

--- a/lib/dnssd.c
+++ b/lib/dnssd.c
@@ -15,156 +15,42 @@
  * modified by fduncanh 2022
  */
 
-/* These defines allow us to compile on iOS */
-#ifndef __has_feature
-# define __has_feature(x) 0
-#endif
-#ifndef __has_extension
-# define __has_extension __has_feature
-#endif
 
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
 #include <assert.h>
+#include <ctype.h>
 
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
-
-#include "compat.h"
-#include <dns_sd.h>
 #include "dnssd.h"
 
 #include "dnssdint.h"
-#include "global.h"
 #include "utils.h"
-
-#define MAX_DEVICEID 18
-#define MAX_SERVNAME 256
-
-#if defined(HAVE_LIBDL) && !defined(__APPLE__)
-# define USE_LIBDL 1
-#else
-# define USE_LIBDL 0
-#endif
-
-#if defined(_WIN32) || USE_LIBDL
-# ifdef _WIN32
-#  include <stdint.h>
-#  if !defined(EFI32) && !defined(EFI64)
-#   define DNSSD_STDCALL __stdcall
-#  else
-#   define DNSSD_STDCALL
-#  endif
-# else
-#  include <dlfcn.h>
-#  define DNSSD_STDCALL
-# endif
-
-typedef struct _DNSServiceRef_t *DNSServiceRef;
-#ifndef _WIN32
-typedef union _TXTRecordRef_t { char PrivateData[16]; char *ForceNaturalAlignment; } TXTRecordRef;
-#endif
-typedef uint32_t DNSServiceFlags;
-typedef int32_t  DNSServiceErrorType;
-
-typedef void (DNSSD_STDCALL *DNSServiceRegisterReply)
-    (
-    DNSServiceRef                       sdRef,
-    DNSServiceFlags                     flags,
-    DNSServiceErrorType                 errorCode,
-    const char                          *name,
-    const char                          *regtype,
-    const char                          *domain,
-    void                                *context
-    );
-
-#else
-//# include <dns_sd.h>
-# define DNSSD_STDCALL
-#endif
-
-typedef DNSServiceErrorType (DNSSD_STDCALL *DNSServiceRegister_t)
-        (
-                DNSServiceRef                       *sdRef,
-                DNSServiceFlags                     flags,
-                uint32_t                            interfaceIndex,
-                const char                          *name,
-                const char                          *regtype,
-                const char                          *domain,
-                const char                          *host,
-                uint16_t                            port,
-                uint16_t                            txtLen,
-                const void                          *txtRecord,
-                DNSServiceRegisterReply             callBack,
-                void                                *context
-        );
-typedef void (DNSSD_STDCALL *DNSServiceRefDeallocate_t)(DNSServiceRef sdRef);
-typedef void (DNSSD_STDCALL *TXTRecordCreate_t)
-        (
-                TXTRecordRef     *txtRecord,
-                uint16_t         bufferLen,
-                void             *buffer
-        );
-typedef void (DNSSD_STDCALL *TXTRecordDeallocate_t)(TXTRecordRef *txtRecord);
-typedef DNSServiceErrorType (DNSSD_STDCALL *TXTRecordSetValue_t)
-        (
-                TXTRecordRef     *txtRecord,
-                const char       *key,
-                uint8_t          valueSize,
-                const void       *value
-        );
-typedef uint16_t (DNSSD_STDCALL *TXTRecordGetLength_t)(const TXTRecordRef *txtRecord);
-typedef const void * (DNSSD_STDCALL *TXTRecordGetBytesPtr_t)(const TXTRecordRef *txtRecord);
-
-
-struct dnssd_s {
-#ifdef WIN32
-    HMODULE module;
-#elif USE_LIBDL
-    void *module;
-#endif
-
-    DNSServiceRegister_t       DNSServiceRegister;
-    DNSServiceRefDeallocate_t  DNSServiceRefDeallocate;
-    TXTRecordCreate_t          TXTRecordCreate;
-    TXTRecordSetValue_t        TXTRecordSetValue;
-    TXTRecordGetLength_t       TXTRecordGetLength;
-    TXTRecordGetBytesPtr_t     TXTRecordGetBytesPtr;
-    TXTRecordDeallocate_t      TXTRecordDeallocate;
-
-    TXTRecordRef raop_record;
-    TXTRecordRef airplay_record;
-
-    DNSServiceRef raop_service;
-    DNSServiceRef airplay_service;
-
-    char *name;
-    int name_len;
-
-    char *hw_addr;
-    int hw_addr_len;
-
-    char *pk;
-
-    uint32_t features1;
-    uint32_t features2;
-
-    unsigned char pin_pw;
-};
-
 
 
 dnssd_t *
-dnssd_init(const char* name, int name_len, const char* hw_addr, int hw_addr_len, int *error, unsigned char pin_pw)
+dnssd_init(const char* name, int name_len, const char* hw_addr, int hw_addr_len, unsigned char pin_pw, int *error)
 {
     /* pin_pw = 0: no pin or password
                 1: use onscreen pin for client access control
                 2 or 3: require password for client access control  
     */
-    
+    const char *dot_local = ".local";
+  
     if (error) *error = DNSSD_ERROR_NOERROR;
+  
+    /* first verify that  name is a null-terminated string with strlen = name_len, and is not ".local" */
+    if (*(name + name_len) != '\0' || name_len != (int) strlen(name) || !strcmp(name, dot_local)) {
+        if (error) *error = DNSSD_ERROR_BADNAME;
+        return NULL;
+    }
+
+    /* use only that part of name before any substring ".local"
+       (this fixes  namespace issues when a custom mDNSResponder is used on macOS) */
+    const char *dot_local_start = strstr(name, dot_local);
+    if (dot_local_start) {
+        name_len = dot_local_start - name;
+    }
 
     dnssd_t *dnssd = (dnssd_t *) calloc(1, sizeof(dnssd_t));
     if (!dnssd) {
@@ -177,7 +63,7 @@ dnssd_init(const char* name, int name_len, const char* hw_addr, int hw_addr_len,
     char *end = NULL;
     unsigned long features  = strtoul(FEATURES_1, &end, 16);
     if (!end || (features & 0xFFFFFFFF) != features) {
-        free (dnssd);
+        free(dnssd);
         if (error) *error = DNSSD_ERROR_BADFEATURES;
         return NULL;
     } 
@@ -185,67 +71,11 @@ dnssd_init(const char* name, int name_len, const char* hw_addr, int hw_addr_len,
 
     features  = strtoul(FEATURES_2, &end, 16);
     if (!end || (features & 0xFFFFFFFF) != features) {
-        free (dnssd);
+        free(dnssd);
         if (error) *error = DNSSD_ERROR_BADFEATURES;
         return NULL;
     } 
     dnssd->features2 = (uint32_t) features;
-
-#ifdef WIN32
-    dnssd->module = LoadLibraryA("dnssd.dll");
-	if (!dnssd->module) {
-		if (error) *error = DNSSD_ERROR_LIBNOTFOUND;
-		free(dnssd);
-		return NULL;
-	}
-	dnssd->DNSServiceRegister = (DNSServiceRegister_t)GetProcAddress(dnssd->module, "DNSServiceRegister");
-	dnssd->DNSServiceRefDeallocate = (DNSServiceRefDeallocate_t)GetProcAddress(dnssd->module, "DNSServiceRefDeallocate");
-	dnssd->TXTRecordCreate = (TXTRecordCreate_t)GetProcAddress(dnssd->module, "TXTRecordCreate");
-	dnssd->TXTRecordSetValue = (TXTRecordSetValue_t)GetProcAddress(dnssd->module, "TXTRecordSetValue");
-	dnssd->TXTRecordGetLength = (TXTRecordGetLength_t)GetProcAddress(dnssd->module, "TXTRecordGetLength");
-	dnssd->TXTRecordGetBytesPtr = (TXTRecordGetBytesPtr_t)GetProcAddress(dnssd->module, "TXTRecordGetBytesPtr");
-	dnssd->TXTRecordDeallocate = (TXTRecordDeallocate_t)GetProcAddress(dnssd->module, "TXTRecordDeallocate");
-
-	if (!dnssd->DNSServiceRegister || !dnssd->DNSServiceRefDeallocate || !dnssd->TXTRecordCreate ||
-	    !dnssd->TXTRecordSetValue || !dnssd->TXTRecordGetLength || !dnssd->TXTRecordGetBytesPtr ||
-	    !dnssd->TXTRecordDeallocate) {
-		if (error) *error = DNSSD_ERROR_PROCNOTFOUND;
-		FreeLibrary(dnssd->module);
-		free(dnssd);
-		return NULL;
-	}
-#elif USE_LIBDL
-    dnssd->module = dlopen("libdns_sd.so", RTLD_LAZY);
-	if (!dnssd->module) {
-		if (error) *error = DNSSD_ERROR_LIBNOTFOUND;
-		free(dnssd);
-		return NULL;
-	}
-	dnssd->DNSServiceRegister = (DNSServiceRegister_t)dlsym(dnssd->module, "DNSServiceRegister");
-	dnssd->DNSServiceRefDeallocate = (DNSServiceRefDeallocate_t)dlsym(dnssd->module, "DNSServiceRefDeallocate");
-	dnssd->TXTRecordCreate = (TXTRecordCreate_t)dlsym(dnssd->module, "TXTRecordCreate");
-	dnssd->TXTRecordSetValue = (TXTRecordSetValue_t)dlsym(dnssd->module, "TXTRecordSetValue");
-	dnssd->TXTRecordGetLength = (TXTRecordGetLength_t)dlsym(dnssd->module, "TXTRecordGetLength");
-	dnssd->TXTRecordGetBytesPtr = (TXTRecordGetBytesPtr_t)dlsym(dnssd->module, "TXTRecordGetBytesPtr");
-	dnssd->TXTRecordDeallocate = (TXTRecordDeallocate_t)dlsym(dnssd->module, "TXTRecordDeallocate");
-
-	if (!dnssd->DNSServiceRegister || !dnssd->DNSServiceRefDeallocate || !dnssd->TXTRecordCreate ||
-	    !dnssd->TXTRecordSetValue || !dnssd->TXTRecordGetLength || !dnssd->TXTRecordGetBytesPtr ||
-	    !dnssd->TXTRecordDeallocate) {
-		if (error) *error = DNSSD_ERROR_PROCNOTFOUND;
-		dlclose(dnssd->module);
-		free(dnssd);
-		return NULL;
-	}
-#else
-    dnssd->DNSServiceRegister = &DNSServiceRegister;
-    dnssd->DNSServiceRefDeallocate = &DNSServiceRefDeallocate;
-    dnssd->TXTRecordCreate = &TXTRecordCreate;
-    dnssd->TXTRecordSetValue = &TXTRecordSetValue;
-    dnssd->TXTRecordGetLength = &TXTRecordGetLength;
-    dnssd->TXTRecordGetBytesPtr = &TXTRecordGetBytesPtr;
-    dnssd->TXTRecordDeallocate = &TXTRecordDeallocate;
-#endif
 
     dnssd->name_len = name_len;
     dnssd->name = calloc(1, name_len + 1);
@@ -267,6 +97,15 @@ dnssd_init(const char* name, int name_len, const char* hw_addr, int hw_addr_len,
 
     memcpy(dnssd->hw_addr, hw_addr, hw_addr_len);
 
+    dnssd->dnssd_private = NULL;
+    dnssd->dnssd_private = dnssd_private_init(dnssd, error);
+    if (!dnssd->dnssd_private) {
+        free(dnssd->hw_addr);
+        free(dnssd->name);
+        free(dnssd);
+        return NULL;
+    }
+
     return dnssd;
 }
 
@@ -274,153 +113,18 @@ void
 dnssd_destroy(dnssd_t *dnssd)
 {
     if (dnssd) {
-#ifdef WIN32
-        FreeLibrary(dnssd->module);
-#elif USE_LIBDL
-        dlclose(dnssd->module);
-#endif
+        if (dnssd->hw_addr) {
+            free(dnssd->hw_addr);
+        }
+        if (dnssd->name) {
+            free(dnssd->name);
+        }
+        if (dnssd->dnssd_private) {
+            dnssd_private_destroy(dnssd->dnssd_private);
+        }
+
         free(dnssd);
     }
-}
-
-int
-dnssd_register_raop(dnssd_t *dnssd, unsigned short port)
-{
-    char servname[MAX_SERVNAME];
-
-    char features[22] = {0};
-
-    assert(dnssd);
-
-    snprintf(features, sizeof(features), "0x%X,0x%X", dnssd->features1, dnssd->features2);
-
-    dnssd->TXTRecordCreate(&dnssd->raop_record, 0, NULL);
-    dnssd->TXTRecordSetValue(&dnssd->raop_record, "ch", strlen(RAOP_CH), RAOP_CH);
-    dnssd->TXTRecordSetValue(&dnssd->raop_record, "cn", strlen(RAOP_CN), RAOP_CN);
-    dnssd->TXTRecordSetValue(&dnssd->raop_record, "da", strlen(RAOP_DA), RAOP_DA);
-    dnssd->TXTRecordSetValue(&dnssd->raop_record, "et", strlen(RAOP_ET), RAOP_ET);
-    dnssd->TXTRecordSetValue(&dnssd->raop_record, "vv", strlen(RAOP_VV), RAOP_VV);
-    dnssd->TXTRecordSetValue(&dnssd->raop_record, "ft", strlen(features), features);
-    dnssd->TXTRecordSetValue(&dnssd->raop_record, "am", strlen(GLOBAL_MODEL), GLOBAL_MODEL);
-    dnssd->TXTRecordSetValue(&dnssd->raop_record, "md", strlen(RAOP_MD), RAOP_MD);
-    dnssd->TXTRecordSetValue(&dnssd->raop_record, "rhd", strlen(RAOP_RHD), RAOP_RHD);
-    switch (dnssd->pin_pw) {
-    case 2:
-    case 3:
-        dnssd->TXTRecordSetValue(&dnssd->raop_record, "pw", strlen("true"), "true");
-        dnssd->TXTRecordSetValue(&dnssd->raop_record, "sf", 4, "0x84");
-        break;
-    case 1:
-        dnssd->TXTRecordSetValue(&dnssd->raop_record, "pw", strlen("true"), "true");
-        dnssd->TXTRecordSetValue(&dnssd->raop_record, "sf", 3, "0x8c");
-        break;
-    default:
-        dnssd->TXTRecordSetValue(&dnssd->raop_record, "pw", strlen("false"), "false");
-        dnssd->TXTRecordSetValue(&dnssd->raop_record, "sf", strlen(RAOP_SF), RAOP_SF);
-        break;
-    }
-    dnssd->TXTRecordSetValue(&dnssd->raop_record, "sr", strlen(RAOP_SR), RAOP_SR);
-    dnssd->TXTRecordSetValue(&dnssd->raop_record, "ss", strlen(RAOP_SS), RAOP_SS);
-    dnssd->TXTRecordSetValue(&dnssd->raop_record, "sv", strlen(RAOP_SV), RAOP_SV);
-    dnssd->TXTRecordSetValue(&dnssd->raop_record, "tp", strlen(RAOP_TP), RAOP_TP);
-    dnssd->TXTRecordSetValue(&dnssd->raop_record, "txtvers", strlen(RAOP_TXTVERS), RAOP_TXTVERS);
-    dnssd->TXTRecordSetValue(&dnssd->raop_record, "sf", strlen(RAOP_SF), RAOP_SF);
-    dnssd->TXTRecordSetValue(&dnssd->raop_record, "vs", strlen(RAOP_VS), RAOP_VS);
-    dnssd->TXTRecordSetValue(&dnssd->raop_record, "vn", strlen(RAOP_VN), RAOP_VN);
-    dnssd->TXTRecordSetValue(&dnssd->raop_record, "pk", strlen(dnssd->pk), dnssd->pk);
-
-    /* Convert hardware address to string */
-    if (utils_hwaddr_raop(servname, sizeof(servname), dnssd->hw_addr, dnssd->hw_addr_len) < 0) {
-        /* FIXME: handle better */
-        return -1;
-    }
-
-    /* Check that we have bytes for 'hw@name' format */
-    if (sizeof(servname) < strlen(servname) + 1 + dnssd->name_len + 1) {
-        /* FIXME: handle better */
-        return -2;
-    }
-
-    strncat(servname, "@", sizeof(servname)-strlen(servname)-1);
-    strncat(servname, dnssd->name, sizeof(servname)-strlen(servname)-1);
-
-    /* Register the service */
-    DNSServiceErrorType retval = dnssd->DNSServiceRegister(&dnssd->raop_service, 0, 0,
-                                                          servname, "_raop._tcp",
-                                                          NULL, NULL,
-                                                          htons(port),
-                                                          dnssd->TXTRecordGetLength(&dnssd->raop_record),
-                                                          dnssd->TXTRecordGetBytesPtr(&dnssd->raop_record),
-                                                          NULL, NULL);
-
-    return (int) retval;   /* error codes are listed in Apple's dns_sd.h */
-}
-
-int
-dnssd_register_airplay(dnssd_t *dnssd, unsigned short port)
-{
-    char device_id[3 * MAX_HWADDR_LEN];
-    char features[22] = {0};
-
-    assert(dnssd);
-
-    snprintf(features, sizeof(features), "0x%X,0x%X", dnssd->features1, dnssd->features2);
-
-    /* Convert hardware address to string */
-    if (utils_hwaddr_airplay(device_id, sizeof(device_id), dnssd->hw_addr, dnssd->hw_addr_len) < 0) {
-        /* FIXME: handle better */
-        return -1;
-    }
-
-    // flags is a string representing a 20-bit flag (up to 3 hex digits)
-    dnssd->TXTRecordCreate(&dnssd->airplay_record, 0, NULL);
-    dnssd->TXTRecordSetValue(&dnssd->airplay_record, "deviceid", strlen(device_id), device_id);
-    dnssd->TXTRecordSetValue(&dnssd->airplay_record, "features", strlen(features), features);
-    switch (dnssd->pin_pw) {
-    case 1:   // display onscreen pin
-        dnssd->TXTRecordSetValue(&dnssd->airplay_record, "pw", strlen("true"), "true");
-        dnssd->TXTRecordSetValue(&dnssd->airplay_record, "flags", 3, "0x4");
-        break;  
-    case 2:  // require password
-    case 3:
-        dnssd->TXTRecordSetValue(&dnssd->airplay_record, "pw", strlen("true"), "true");
-        dnssd->TXTRecordSetValue(&dnssd->airplay_record, "flags", 3, "0x4");
-        break;
-    default:
-        dnssd->TXTRecordSetValue(&dnssd->airplay_record, "pw", strlen("false"), "false");
-        dnssd->TXTRecordSetValue(&dnssd->airplay_record, "flags", 3, "0x4");
-        break;
-    }
-    dnssd->TXTRecordSetValue(&dnssd->airplay_record, "model", strlen(GLOBAL_MODEL), GLOBAL_MODEL);
-    dnssd->TXTRecordSetValue(&dnssd->airplay_record, "pk", strlen(dnssd->pk), dnssd->pk);
-    dnssd->TXTRecordSetValue(&dnssd->airplay_record, "pi", strlen(AIRPLAY_PI), AIRPLAY_PI);
-    dnssd->TXTRecordSetValue(&dnssd->airplay_record, "srcvers", strlen(AIRPLAY_SRCVERS), AIRPLAY_SRCVERS);
-    dnssd->TXTRecordSetValue(&dnssd->airplay_record, "vv", strlen(AIRPLAY_VV), AIRPLAY_VV);
-
-    /* Register the service */
-    DNSServiceErrorType retval = dnssd->DNSServiceRegister(&dnssd->airplay_service, 0, 0,
-                                                           dnssd->name, "_airplay._tcp",
-                                                           NULL, NULL,
-                                                           htons(port),
-                                                           dnssd->TXTRecordGetLength(&dnssd->airplay_record),
-                                                           dnssd->TXTRecordGetBytesPtr(&dnssd->airplay_record),
-                                                           NULL, NULL);
-
-    return (int) retval;   /* error codes are listed in Apple's dns_sd.h */
-}
-
-const char *
-dnssd_get_raop_txt(dnssd_t *dnssd, int *length)
-{
-    *length = dnssd->TXTRecordGetLength(&dnssd->raop_record);
-    return dnssd->TXTRecordGetBytesPtr(&dnssd->raop_record);
-}
-
-const char *
-dnssd_get_airplay_txt(dnssd_t *dnssd, int *length)
-{
-    *length = dnssd->TXTRecordGetLength(&dnssd->airplay_record);
-    return dnssd->TXTRecordGetBytesPtr(&dnssd->airplay_record);
 }
 
 const char *
@@ -435,48 +139,6 @@ dnssd_get_hw_addr(dnssd_t *dnssd, int *length)
 {
     *length = dnssd->hw_addr_len;
     return dnssd->hw_addr;
-}
-
-void
-dnssd_unregister_raop(dnssd_t *dnssd)
-{
-    assert(dnssd);
-
-    if (!dnssd->raop_service) {
-        return;
-    }
-
-    /* Deallocate TXT record */
-    dnssd->TXTRecordDeallocate(&dnssd->raop_record);
-
-    dnssd->DNSServiceRefDeallocate(dnssd->raop_service);
-    dnssd->raop_service = NULL;
-
-    if (dnssd->airplay_service == NULL) {
-        free(dnssd->name);
-        free(dnssd->hw_addr);
-    }
-}
-
-void
-dnssd_unregister_airplay(dnssd_t *dnssd)
-{
-    assert(dnssd);
-
-    if (!dnssd->airplay_service) {
-        return;
-    }
-
-    /* Deallocate TXT record */
-    dnssd->TXTRecordDeallocate(&dnssd->airplay_record);
-
-    dnssd->DNSServiceRefDeallocate(dnssd->airplay_service);
-    dnssd->airplay_service = NULL;
-
-    if (dnssd->raop_service == NULL) {
-        free(dnssd->name);
-        free(dnssd->hw_addr);
-    }
 }
 
 uint64_t dnssd_get_airplay_features(dnssd_t *dnssd) {

--- a/lib/dnssd.h
+++ b/lib/dnssd.h
@@ -52,7 +52,8 @@ typedef struct dnssd_s {
 
 void *dnssd_private_init(dnssd_t *dnssd_public, int *error);
 void dnssd_private_destroy(void *dnssd_private);
-  
+void dnssd_error_text(int *error, const char *appname);
+
 DNSSD_API dnssd_t *dnssd_init(const char *name, int name_len, const char *hw_addr, int hw_addr_len, unsigned char pin_pw, int *error);
 
 DNSSD_API int dnssd_register_raop(dnssd_t *dnssd, unsigned short port);

--- a/lib/dnssd.h
+++ b/lib/dnssd.h
@@ -30,10 +30,30 @@ extern "C" {
 #define DNSSD_ERROR_LIBNOTFOUND   3
 #define DNSSD_ERROR_PROCNOTFOUND  4
 #define DNSSD_ERROR_BADFEATURES   5
+#define DNSSD_ERROR_BADNAME       6
 
-typedef struct dnssd_s dnssd_t;
+typedef struct dnssd_s {
 
-DNSSD_API dnssd_t *dnssd_init(const char *name, int name_len, const char *hw_addr, int hw_addr_len, int *error, unsigned char pin_pw);
+    char *name;
+    int name_len;
+
+    char *hw_addr;
+    int hw_addr_len;
+
+    char *pk;
+
+    uint32_t features1;
+    uint32_t features2;
+
+    unsigned char pin_pw;
+
+    void *dnssd_private;
+} dnssd_t;
+
+void *dnssd_private_init(dnssd_t *dnssd_public, int *error);
+void dnssd_private_destroy(void *dnssd_private);
+  
+DNSSD_API dnssd_t *dnssd_init(const char *name, int name_len, const char *hw_addr, int hw_addr_len, unsigned char pin_pw, int *error);
 
 DNSSD_API int dnssd_register_raop(dnssd_t *dnssd, unsigned short port);
 DNSSD_API int dnssd_register_airplay(dnssd_t *dnssd, unsigned short port);

--- a/uxplay.cpp
+++ b/uxplay.cpp
@@ -1983,7 +1983,7 @@ static int start_dnssd(std::vector<char> hw_addr, std::string name) {
               = 3: client must enter randoe 4-digit password displayed like an  onscreen pin (every access)
               = 0:  no access control
     */
-    dnssd = dnssd_init(name.c_str(), strlen(name.c_str()), hw_addr.data(), hw_addr.size(), &dnssd_error, pin_pw);
+    dnssd = dnssd_init(name.c_str(), strlen(name.c_str()), hw_addr.data(), hw_addr.size(), pin_pw, &dnssd_error);
     if (dnssd_error) {
         LOGE("Could not initialize dnssd library!: error %d", dnssd_error);
         return 1;

--- a/uxplay.cpp
+++ b/uxplay.cpp
@@ -1914,23 +1914,14 @@ static int parse_dmap_header(const unsigned char *metadata, char *tag, int *len)
 
 static int register_dnssd() {
     int dnssd_error;
+    int dnssd_type = 0;
     uint64_t features;
     
     dnssd_error = dnssd_register_raop(dnssd, raop_port);
     if (dnssd_error) {
         if (ble_filename.empty()) {
-            if (dnssd_error == -65537) {
-                LOGE("No DNS-SD Server found (DNSServiceRegister call returned kDNSServiceErr_Unknown)");
-            } else if (dnssd_error == -65548) {
-                LOGE("DNSServiceRegister call returned kDNSServiceErr_NameConflict");
-                LOGI("Is another instance of %s running with the same DeviceID (MAC address) or using same network ports?",
-                     DEFAULT_NAME);
-                LOGI("Use options -m ... and -p ... to allow multiple instances of %s to run concurrently", DEFAULT_NAME); 
-            } else {
-                LOGE("dnssd_register_raop failed with error code %d\n"
-                     "mDNS Error codes are in range FFFE FF00 (-65792) to FFFE FFFF (-65537) "
-                     "(see Apple's dns_sd.h)", dnssd_error);
-            }
+            LOGE("dnssd_register_raop failed with error code %d", dnssd_error);
+            dnssd_error_text(&dnssd_error, appname);
             return -3;
         } else {
             LOGI("dnssd_register_raop failed: ignoring because Bluetooth LE service discovery may be available");
@@ -1940,9 +1931,8 @@ static int register_dnssd() {
     dnssd_error = dnssd_register_airplay(dnssd, airplay_port);
     if (dnssd_error) {
         if (ble_filename.empty()) {
-            LOGE("dnssd_register_airplay failed with error code %d\n"
-                 "mDNS Error codes are in range FFFE FF00 (-65792) to FFFE FFFF (-65537) "
-                 "(see Apple's dns_sd.h)", dnssd_error);
+            LOGE("dnssd_register_airplay failed with error code %d", dnssd_error);
+            dnssd_error_text(&dnssd_error, appname);
             return -4;
         } else {
             LOGI("dnssd_register_airplay failed: ignoring because Bluetooth LE service discovery may be available");   


### PR DESCRIPTION
will allow the kgbook mdnsd to added as an alternative to dns_sd.h (Apple/avahi)