### PR TITLE
Add experimental --no-audio-advertise option (narrow AirPlay advertisement)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Build
         run: cmake --build build --parallel
 
+      - name: Run tests
+        run: ctest --test-dir build --output-on-failure
+
       - name: Verify binary
         run: |
           test -x build/uxplay
@@ -85,6 +88,9 @@ jobs:
 
       - name: Build
         run: cmake --build build --parallel
+
+      - name: Run tests
+        run: ctest --test-dir build --output-on-failure
 
       - name: Verify binary
         run: |
@@ -126,6 +132,10 @@ jobs:
       - name: Build
         shell: msys2 {0}
         run: cmake --build build --parallel
+
+      - name: Run tests
+        shell: msys2 {0}
+        run: ctest --test-dir build --output-on-failure
 
       - name: Verify binary
         shell: msys2 {0}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,7 @@ if  ( GST_MACOS )
      message ( STATUS "define GST_MACOS" )
 endif()
 
-add_executable( uxplay uxplay.cpp )
+add_executable( uxplay uxplay.cpp audio_advertise.cpp )
 target_link_libraries( uxplay renderers airplay )
 if (DBUS_FOUND)
       target_link_libraries( uxplay ${DBUS_LIBRARY})
@@ -112,6 +112,12 @@ install( FILES Bluetooth_LE_beacon/uxplay_beacon_module_HCI.py
          PERMISSIONS OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ)
 endif()
 
+
+option( BUILD_TESTS "Build UxPlay unit tests" ON )
+if ( BUILD_TESTS )
+  enable_testing()
+  add_subdirectory( tests )
+endif()
 
 # uninstall target
 if(NOT TARGET uninstall)

--- a/README.md
+++ b/README.md
@@ -1454,7 +1454,37 @@ GStreamer documentation), and some choices of audiosink might not work
 on your system.
 
 **-as 0** (or just **-a**) suppresses playing of streamed audio, but
-displays streamed video.
+displays streamed video. **This only disables audio playback on the UxPlay
+server itself.** It does not change what UxPlay advertises to the client, so
+macOS/iOS may still select UxPlay as the system audio output during
+mirroring, and the user may experience silence with no obvious cause. When
+`-a`/`-as 0` is used without `--no-audio-advertise` (below), UxPlay logs a
+startup warning about this.
+
+**-naa \[*mode*\]** (or **--no-audio-advertise \[*mode*\]**) is an
+**experimental** option that narrows the AirPlay/DNS-SD advertisement itself,
+in an attempt to stop macOS/iOS from selecting UxPlay as an audio output in
+the first place, rather than merely muting playback after the fact. It
+implies `-a`. Optional *mode* is one of:
+
+- **bits** — clear the AirPlay feature bits that claim audio support (bit 9
+  and related bits) in the advertised `features`/`ft` values.
+- **raop** — do not register the `_raop._tcp` (AirTunes) service at all.
+- **both** (default, used when *mode* is omitted) — both of the above.
+
+This is genuinely experimental: clearing the audio-support feature bit is
+known, from upstream testing (see issues
+[#303](https://github.com/FDH2/UxPlay/issues/303),
+[#442](https://github.com/FDH2/UxPlay/issues/442), and
+[#489](https://github.com/FDH2/UxPlay/issues/489)), to make some AirPlay
+clients send a `TEARDOWN` request roughly 30–60 seconds into a mirroring
+session, ending it. No fix for that client-side behavior is known. See
+[`specs/no-audio-advertisement.md`](specs/no-audio-advertisement.md) for the
+full rationale and known risks, and
+[`docs/manual-test-no-audio-advertise.md`](docs/manual-test-no-audio-advertise.md)
+for a real-device verification procedure. Because of the unresolved
+teardown behavior, this is not the default and is not recommended for
+routine use yet.
 
 **-al *x*** specifies an audio latency *x* in (decimal) seconds in
 Audio-only (ALAC), that is reported to the client. Values in the range
@@ -2135,6 +2165,32 @@ be changed in global.h. UxPlay also works if it declares itself as an
 AppleTV6,2 with sourceVersion 380.20.1 (an AppleTV 4K 1st gen,
 introduced 2017, running tvOS 12.2.1), so it does not seem to matter
 what version UxPlay claims to be.
+
+### 7. macOS/iOS routes audio to UxPlay even though audio playback was disabled.
+
+This happens because `-a` (and `-as 0`) only stop UxPlay from *playing*
+received audio locally — they do not change what UxPlay *advertises* to the
+client. The client has no way to know the server doesn't want to be used for
+audio, so macOS in particular may still pick UxPlay as the system audio
+output when screen mirroring starts, and the user gets silence instead of
+sound with no clear explanation. As of this version, `-a`/`-as 0` used alone
+prints a startup warning explaining this.
+
+The **experimental** `--no-audio-advertise` (or `-naa`) option, described
+above in the Usage section, narrows the actual AirPlay/DNS-SD advertisement
+instead of only muting local playback. It is not the default because
+clearing the AirPlay "audio supported" feature bit is known, from upstream
+issues [#303](https://github.com/FDH2/UxPlay/issues/303),
+[#442](https://github.com/FDH2/UxPlay/issues/442) and
+[#489](https://github.com/FDH2/UxPlay/issues/489), to make some clients send
+a `TEARDOWN` request roughly 30–60 seconds into the mirroring session — a
+client-side AirPlay protocol behavior with no known fix (it was reproduced
+against an independent, unrelated AirPlay server implementation, ruling out
+a UxPlay-specific bug). See
+[`specs/no-audio-advertisement.md`](specs/no-audio-advertisement.md) for
+details and
+[`docs/manual-test-no-audio-advertise.md`](docs/manual-test-no-audio-advertise.md)
+for how to verify behavior on real hardware.
 
 # Changelog
 1.74  2026-06-21  Optional minimal internal mDNSResponder to replace

--- a/audio_advertise.cpp
+++ b/audio_advertise.cpp
@@ -1,0 +1,36 @@
+#include "audio_advertise.h"
+
+bool uxplay_is_no_audio_advertise_flag(const std::string &arg) {
+    return arg == "--no-audio-advertise" || arg == "-naa";
+}
+
+bool uxplay_parse_no_audio_advertise_mode(const std::string &token, bool &clear_bits, bool &skip_raop) {
+    if (token == "bits") {
+        clear_bits = true;
+        skip_raop = false;
+        return true;
+    }
+    if (token == "raop") {
+        clear_bits = false;
+        skip_raop = true;
+        return true;
+    }
+    if (token == "both") {
+        clear_bits = true;
+        skip_raop = true;
+        return true;
+    }
+    return false;
+}
+
+bool uxplay_should_register_raop(bool naa_skip_raop) {
+    return !naa_skip_raop;
+}
+
+bool uxplay_should_warn_audio_advertise(bool use_audio, bool no_audio_advertise) {
+    return !use_audio && !no_audio_advertise;
+}
+
+bool uxplay_should_warn_audio_still_playing(bool use_audio, bool no_audio_advertise) {
+    return no_audio_advertise && use_audio;
+}

--- a/audio_advertise.h
+++ b/audio_advertise.h
@@ -1,0 +1,36 @@
+/*
+ * Pure decision logic for the "--no-audio-advertise" experimental option.
+ * See specs/no-audio-advertisement.md for the behavior these functions encode.
+ *
+ * Kept dependency-free (only <string>) so it can be unit-tested without
+ * linking the rest of uxplay.cpp (GStreamer, D-Bus, etc.).
+ */
+
+#ifndef UXPLAY_AUDIO_ADVERTISE_H
+#define UXPLAY_AUDIO_ADVERTISE_H
+
+#include <string>
+
+/* recognizes "--no-audio-advertise" and its short alias "-naa" */
+bool uxplay_is_no_audio_advertise_flag(const std::string &arg);
+
+/*
+ * Parses the optional trailing mode token for --no-audio-advertise
+ * ("bits" | "raop" | "both"). On success, sets clear_bits and skip_raop and
+ * returns true. On an unrecognized token, leaves the outputs untouched and
+ * returns false (caller should treat this as a CLI error).
+ */
+bool uxplay_parse_no_audio_advertise_mode(const std::string &token, bool &clear_bits, bool &skip_raop);
+
+/* whether register_dnssd() should call dnssd_register_raop() */
+bool uxplay_should_register_raop(bool naa_skip_raop);
+
+/* "-a"/"-as 0" used without narrowing the advertisement: local audio is off,
+ * but a client may still be routed audio it can't hear. */
+bool uxplay_should_warn_audio_advertise(bool use_audio, bool no_audio_advertise);
+
+/* defensive/documentation guard: --no-audio-advertise always forces
+ * use_audio=false, so this should never be true in practice. */
+bool uxplay_should_warn_audio_still_playing(bool use_audio, bool no_audio_advertise);
+
+#endif

--- a/docs/manual-test-no-audio-advertise.md
+++ b/docs/manual-test-no-audio-advertise.md
@@ -1,0 +1,130 @@
+# Manual verification: `--no-audio-advertise`
+
+This procedure requires real hardware and cannot be automated: it exercises
+actual macOS/iOS AirPlay client behavior and real mDNS traffic on a LAN.
+Automated coverage (CLI parsing, exact feature-bitmask values, RAOP
+registration decision, help text) is in `tests/`; see
+`specs/no-audio-advertisement.md` §5 for what is and isn't covered there.
+
+Read `specs/no-audio-advertisement.md` first, especially §4 ("Known risks")
+— upstream issues #303/#442/#489 already found that clearing the AirPlay
+audio-supported feature bit causes some clients to send a `TEARDOWN` request
+roughly 30–60 seconds into mirroring, with no known fix. Expect to reproduce
+that in step 2 below; the `raop` mode in step 2c is the genuinely open
+question (untested by upstream).
+
+For each run: note the UxPlay version/commit, the client device and OS
+version, and keep the full `-d` debug log.
+
+## 1. Baseline: `-a` (confirms the new warning, and the pre-existing gap it warns about)
+
+On the Linux/macOS server:
+
+```bash
+uxplay -d -a
+```
+
+From a Mac or iOS device on the same network:
+
+1. Confirm the server log prints:
+   `Audio playback is disabled locally, but UxPlay still advertises audio support. macOS/iOS may still route audio to this receiver.`
+2. Start screen mirroring to UxPlay.
+3. Check whether macOS/iOS switches its audio output to UxPlay (Control
+   Center / Sound settings).
+4. Confirm whether audio becomes silent (server should produce no audio
+   output, since `-a` is in effect).
+5. Keep the session alive for at least 90 seconds; note whether it stays
+   connected or disconnects.
+6. Save the full UxPlay debug log.
+
+Expected (this is the documented, pre-existing gap this feature addresses):
+the client may still select UxPlay as its audio output, resulting in
+silence, because `-a` does not change the advertisement.
+
+## 2. Experimental mode: `--no-audio-advertise`
+
+Repeat the following for **each** of the three modes. Run them as separate,
+independent sessions (restart `uxplay` between modes).
+
+### 2a. `bits` mode (reproduces upstream's tested, known-teardown configuration)
+
+```bash
+uxplay -d --no-audio-advertise bits
+```
+
+- Confirm the log prints:
+  `Experimental no-audio advertisement mode enabled. Some AirPlay clients may disconnect after 30/60 seconds if they require an audio stream during mirroring.`
+- Confirm the debug log's `register_dnssd: advertised AirPlay service with
+  "Features" code = 0x...` line shows `0x5243F4E6` (see
+  `specs/no-audio-advertisement.md` for how this value is derived).
+- Start screen mirroring. Check whether macOS keeps local speakers/headphones
+  as the audio output, or still selects UxPlay.
+- Keep the session alive for **at least 90 seconds**. Watch specifically for
+  an RTSP `TEARDOWN` in the debug log around the 30–60 second mark, and note
+  the exact elapsed time if it occurs.
+- Save the full debug log.
+
+### 2b. `raop` mode (untested by upstream — the primary open question)
+
+```bash
+uxplay -d --no-audio-advertise raop
+```
+
+- Confirm the log prints the "skipping `_raop._tcp` registration" line.
+- Repeat the same mirroring/90-second/TEARDOWN observations as 2a.
+- Since the feature bitmask is untouched in this mode, also note whether the
+  client behaves differently from the `-a`-alone baseline (step 1) purely
+  from `_raop._tcp` being absent.
+
+### 2c. `both` mode (default — combination, also untested by upstream)
+
+```bash
+uxplay -d --no-audio-advertise
+```
+
+- Confirm both log lines from 2a and 2b appear.
+- Repeat the same mirroring/90-second/TEARDOWN observations.
+- Compare against 2a and 2b: does combining the two change the teardown
+  timing at all, or behave identically to `bits` alone?
+
+## 3. Service discovery inspection
+
+From a Mac (or any host with `dns-sd`), compare what's advertised in each
+mode above:
+
+```bash
+dns-sd -B _airplay._tcp
+dns-sd -B _raop._tcp
+```
+
+Expected:
+- `_airplay._tcp`: UxPlay's instance should appear in every mode (baseline,
+  `bits`, `raop`, `both`).
+- `_raop._tcp`: UxPlay's instance should appear in the baseline and `bits`
+  modes, and should be **absent** in `raop` and `both` modes.
+
+To inspect the actual TXT record content (e.g. to confirm the `features`/`ft`
+value on the wire matches what the debug log reports), resolve the service
+and dump its TXT record:
+
+```bash
+dns-sd -L "<UxPlay instance name>" _airplay._tcp local
+dns-sd -Z _airplay._tcp local   # zone-file-style dump, includes TXT records
+```
+
+## 4. Reporting results
+
+For each of the four runs (baseline, `bits`, `raop`, `both`), record:
+
+- Did the client select UxPlay as its audio output?
+- Did the session survive 90+ seconds, or did it TEARDOWN? At what elapsed
+  time?
+- Did `_raop._tcp` appear/disappear as expected?
+- Anything unexpected in the debug log.
+
+If `raop` or `both` mode avoids the TEARDOWN that `bits` alone reproduces,
+that is a significant finding for the still-open upstream issues
+[#303](https://github.com/FDH2/UxPlay/issues/303),
+[#442](https://github.com/FDH2/UxPlay/issues/442), and
+[#489](https://github.com/FDH2/UxPlay/issues/489) — worth reporting back
+upstream with the full debug logs from this procedure.

--- a/docs/manual-test-no-audio-advertise.md
+++ b/docs/manual-test-no-audio-advertise.md
@@ -75,6 +75,15 @@ uxplay -d --no-audio-advertise raop
 - Since the feature bitmask is untouched in this mode, also note whether the
   client behaves differently from the `-a`-alone baseline (step 1) purely
   from `_raop._tcp` being absent.
+- Also run the `GET /info` wire probe from §3 below: `txtRAOP` must be absent
+  from the response, and the debug log should show the
+  `raop_handler_info: raop TXT record empty (service not registered), omitting txtRAOP`
+  line when the probe runs.
+- Note: AirPlay feature bit 30 ("RAOP support: with this bit set, the AirTunes
+  service is not required") is still set in this mode, so a client may treat
+  the `_airplay._tcp` port itself as RAOP-capable. If you want to go further,
+  bit 30 can additionally be cleared in the source (one line:
+  `dnssd_set_airplay_features(dnssd, 30, 0)`) — report results upstream.
 
 ### 2c. `both` mode (default — combination, also untested by upstream)
 
@@ -111,6 +120,26 @@ and dump its TXT record:
 dns-sd -L "<UxPlay instance name>" _airplay._tcp local
 dns-sd -Z _airplay._tcp local   # zone-file-style dump, includes TXT records
 ```
+
+### BLE / `GET /info` path (no BLE hardware needed)
+
+UxPlay also serves both TXT record contents over its RTSP `GET /info`
+handler; this is the path Bluetooth LE service discovery uses. The BLE-shaped
+branch triggers on any CSeq-less RTSP/1.0 request whose URL contains the
+`txtAirPlay`/`txtRAOP` tokens, so it can be probed with plain `nc` from any
+host — no BLE hardware required (`curl` won't work: it speaks HTTP/1.1, and
+this branch requires RTSP/1.0). The port is the TCP port advertised by the
+`_airplay._tcp` service (shown by `dns-sd -L` above; UxPlay uses one port for
+both services):
+
+```bash
+printf 'GET /info?txtAirPlay?txtRAOP RTSP/1.0\r\n\r\n' | nc <server-ip> <port>
+```
+
+Expected: the binary-plist response body contains the `txtAirPlay` key in
+every mode, and contains `txtRAOP` only in the baseline and `bits` modes. In
+`raop` and `both` modes `txtRAOP` must be **absent** (not present-but-empty),
+and the server's `-d` log should print the "omitting txtRAOP" debug line.
 
 ## 4. Reporting results
 

--- a/lib/dnssd.c
+++ b/lib/dnssd.c
@@ -151,6 +151,71 @@ void dnssd_set_pk(dnssd_t *dnssd, char * pk_str) {
     dnssd->pk = pk_str;
 }
 
+void dnssd_set_default_airplay_features(dnssd_t *dnssd, int hls_support, int h265_support, int setup_legacy_pairing) {
+    /* default: FEATURES_1 = 0x5A7FFEE6, FEATURES_2 = 0 */
+
+    dnssd_set_airplay_features(dnssd,  0, 0); // AirPlay video supported
+    dnssd_set_airplay_features(dnssd,  1, 1); // photo supported
+    dnssd_set_airplay_features(dnssd,  2, 1); // video protected with FairPlay DRM
+    dnssd_set_airplay_features(dnssd,  3, 0); // volume control supported for videos
+
+    dnssd_set_airplay_features(dnssd,  4, 0); // http live streaming (HLS) supported
+    dnssd_set_airplay_features(dnssd,  5, 1); // slideshow supported
+    dnssd_set_airplay_features(dnssd,  6, 1); //
+    dnssd_set_airplay_features(dnssd,  7, 1); // mirroring supported
+
+    dnssd_set_airplay_features(dnssd,  8, 0); // screen rotation  supported
+    dnssd_set_airplay_features(dnssd,  9, 1); // audio supported
+    dnssd_set_airplay_features(dnssd, 10, 1); //
+    dnssd_set_airplay_features(dnssd, 11, 1); // audio packet redundancy supported
+
+    dnssd_set_airplay_features(dnssd, 12, 1); // FaiPlay secure auth supported
+    dnssd_set_airplay_features(dnssd, 13, 1); // photo preloading  supported
+    dnssd_set_airplay_features(dnssd, 14, 1); // Authentication bit 4:  FairPlay authentication
+    dnssd_set_airplay_features(dnssd, 15, 1); // Metadata bit 1 support:   Artwork
+
+    dnssd_set_airplay_features(dnssd, 16, 1); // Metadata bit 2 support:  Soundtrack  Progress
+    dnssd_set_airplay_features(dnssd, 17, 1); // Metadata bit 0 support:  Text (DAACP) "Now Playing" info.
+    dnssd_set_airplay_features(dnssd, 18, 1); // Audio format 1 support:
+    dnssd_set_airplay_features(dnssd, 19, 1); // Audio format 2 support: must be set for AirPlay 2 multiroom audio
+
+    dnssd_set_airplay_features(dnssd, 20, 1); // Audio format 3 support: must be set for AirPlay 2 multiroom audio
+    dnssd_set_airplay_features(dnssd, 21, 1); // Audio format 4 support:
+    dnssd_set_airplay_features(dnssd, 22, 1); // Authentication type 4: FairPlay authentication
+    dnssd_set_airplay_features(dnssd, 23, 0); // Authentication type 1: RSA Authentication
+
+    dnssd_set_airplay_features(dnssd, 24, 0); //
+    dnssd_set_airplay_features(dnssd, 25, 1); //
+    dnssd_set_airplay_features(dnssd, 26, 0); // Has Unified Advertiser info
+    dnssd_set_airplay_features(dnssd, 27, 1); // Supports Legacy Pairing
+
+    dnssd_set_airplay_features(dnssd, 28, 1); //
+    dnssd_set_airplay_features(dnssd, 29, 0); //
+    dnssd_set_airplay_features(dnssd, 30, 1); // RAOP support: with this bit set, the AirTunes service is not required.
+    dnssd_set_airplay_features(dnssd, 31, 0); //
+
+    /* needed for HLS video support */
+    dnssd_set_airplay_features(dnssd, 0, (int) hls_support);
+    dnssd_set_airplay_features(dnssd, 4, (int) hls_support);
+
+    /* needed for h265 video support */
+    dnssd_set_airplay_features(dnssd, 42, (int) h265_support);
+
+    /* bit 27 of Features determines whether the AirPlay2 client-pairing protocol will be used (1) or not (0) */
+    dnssd_set_airplay_features(dnssd, 27, (int) setup_legacy_pairing);
+}
+
+void dnssd_apply_no_audio_advertise(dnssd_t *dnssd) {
+    /* clears the feature bits that claim audio support/capability; see
+     * specs/no-audio-advertisement.md "--no-audio-advertise bits" mode */
+    dnssd_set_airplay_features(dnssd,  9, 0); // audio supported
+    dnssd_set_airplay_features(dnssd, 11, 0); // audio packet redundancy supported
+    dnssd_set_airplay_features(dnssd, 18, 0); // Audio format 1 support
+    dnssd_set_airplay_features(dnssd, 19, 0); // Audio format 2 support
+    dnssd_set_airplay_features(dnssd, 20, 0); // Audio format 3 support
+    dnssd_set_airplay_features(dnssd, 21, 0); // Audio format 4 support
+}
+
 void dnssd_set_airplay_features(dnssd_t *dnssd, int bit, int val) {
     uint32_t mask = 0;
     uint32_t *features = 0;

--- a/lib/dnssd.h
+++ b/lib/dnssd.h
@@ -70,6 +70,14 @@ DNSSD_API void dnssd_set_airplay_features(dnssd_t *dnssd, int bit, int val);
 DNSSD_API uint64_t dnssd_get_airplay_features(dnssd_t *dnssd);
 DNSSD_API void dnssd_set_pk(dnssd_t *dnssd, char * pk_str);
 
+/* sets the default AirPlay feature bitmask (moved verbatim from uxplay.cpp's
+ * start_dnssd(), see specs/no-audio-advertisement.md) */
+DNSSD_API void dnssd_set_default_airplay_features(dnssd_t *dnssd, int hls_support, int h265_support, int setup_legacy_pairing);
+
+/* clears the feature bits that claim audio support (9, 11, 18, 19, 20, 21);
+ * used by the experimental "--no-audio-advertise bits"/"both" modes */
+DNSSD_API void dnssd_apply_no_audio_advertise(dnssd_t *dnssd);
+
 DNSSD_API void dnssd_destroy(dnssd_t *dnssd);
 
 #ifdef __cplusplus

--- a/lib/raop_handlers.h
+++ b/lib/raop_handlers.h
@@ -93,16 +93,26 @@ raop_handler_info(raop_conn_t *conn,
         add_txt_raop = (bool) strstr(url, txtRAOP);
     }
     
+    /* never emit an empty TXT record: if a service was not registered
+     * (e.g. --no-audio-advertise raop|both skipped dnssd_register_raop),
+     * its TXT buffer was never built and the getter returns length 0 */
     if (add_txt_airplay) {
         const char *txt = dnssd_get_airplay_txt(raop->dnssd, &len);
-        plist_t txt_airplay_node = plist_new_data(txt, len);
-        plist_dict_set_item(res_node, txtAirPlay, txt_airplay_node);
+        if (txt && len > 0) {
+            plist_t txt_airplay_node = plist_new_data(txt, len);
+            plist_dict_set_item(res_node, txtAirPlay, txt_airplay_node);
+        }
     }
 
     if (add_txt_raop) {
         const char *txt = dnssd_get_raop_txt(raop->dnssd, &len);
-        plist_t txt_raop_node = plist_new_data(txt, len);
-        plist_dict_set_item(res_node, txtRAOP, txt_raop_node);
+        if (txt && len > 0) {
+            plist_t txt_raop_node = plist_new_data(txt, len);
+            plist_dict_set_item(res_node, txtRAOP, txt_raop_node);
+        } else {
+            logger_log(raop->logger, LOGGER_DEBUG,
+                       "raop_handler_info: raop TXT record empty (service not registered), omitting txtRAOP");
+        }
     }
   
     /* don't need anything below here in the response to initial  "txtAirPlay" GET/info request */

--- a/specs/no-audio-advertisement.md
+++ b/specs/no-audio-advertisement.md
@@ -1,0 +1,187 @@
+# Spec: stop UxPlay from advertising audio support (`--no-audio-advertise`)
+
+Status: experimental. Applies to the `uxplay` server only. Does not change the AirPlay/RAOP
+wire protocol itself, does not bypass FairPlay/DRM/MFi, and does not implement AirPlay 2
+multi-room audio.
+
+## 1. Current behavior
+
+- `uxplay -a` and `uxplay -as 0` are equivalent (`-as 0` is converted to `-a`'s effect at
+  startup). Both set the internal `use_audio` flag to `false`.
+- `use_audio = false` **only** affects the local GStreamer audio-rendering pipeline on the
+  server: `audio_renderer_init()` is skipped, the audio bus watch is not installed, and the
+  `audio_process`/`audio_get_format`/`audio_set_volume`/`audio_flush` RAOP callbacks become
+  no-ops. No received audio is played on the machine running UxPlay.
+- `-a`/`-as 0` do **not** change anything about how UxPlay advertises itself over
+  DNS-SD/mDNS. Specifically, with `-a`:
+  - UxPlay still registers the `_raop._tcp` service (AirPlay/AirTunes audio-receiver
+    discovery), unconditionally, with a full, unmodified TXT record.
+  - UxPlay still advertises AirPlay feature bit 9 ("audio supported") as `1` in both the
+    `_airplay._tcp` TXT record's `features` field and the `_raop._tcp` TXT record's `ft`
+    field, along with bits 11, 18, 19, 20, 21 (audio packet redundancy and audio format
+    1–4 support).
+- Consequence: a macOS or iOS client has no signal, at discovery or connection time, that
+  this particular UxPlay instance doesn't want to be used for audio. macOS in particular may
+  automatically select UxPlay as the system audio output when screen mirroring starts. With
+  `-a`, the practical result for the user is **silence**, with no indication of why — the
+  client believes it successfully routed audio to a working audio receiver.
+- This is confirmed by tracing every use of the `use_audio` variable in `uxplay.cpp`: all
+  call sites are inside the server-side rendering/playback path. None of them touch
+  `start_dnssd()`, `register_dnssd()`, or the DNS-SD feature bitmask.
+
+## 2. Desired behavior
+
+Add an explicit, opt-in, experimental CLI option:
+
+```
+uxplay --no-audio-advertise [bits|raop|both]
+```
+
+Short alias: `-naa` (does not collide with any existing UxPlay option).
+
+Bare `--no-audio-advertise` (no trailing token) is equivalent to `--no-audio-advertise both`.
+
+| Mode | Effect |
+|---|---|
+| `bits` | Clear AirPlay feature bits 9, 11, 18, 19, 20, 21 in the advertised `features`/`ft` bitmask (both `_airplay._tcp` and `_raop._tcp` TXT records derive from the same bitmask). This is **exactly** the configuration already tested upstream in issues #303/#442/#489 (see §4). |
+| `raop` | Skip registration of the `_raop._tcp` service entirely — it will not appear in `dns-sd -B _raop._tcp` output at all. The feature bitmask is left at its normal default. This combination has **not** been tested upstream. |
+| `both` (default) | Both of the above — the narrowest advertisement UxPlay can currently produce that still offers `_airplay._tcp` mirroring. |
+
+In every mode, `--no-audio-advertise` **implies local audio playback is disabled**
+(`use_audio` is forced to `false`), regardless of `-as <sink>` or argument order. There is no
+way to narrow the advertisement while keeping local playback on — the task and this spec
+treat that combination as nonsensical, not as something requiring a hard CLI error.
+
+No CLI combination involving `--no-audio-advertise` is rejected as an error; ordering
+relative to `-a`/`-as` does not matter, since `--no-audio-advertise` always wins on
+`use_audio`.
+
+## 3. Non-goals
+
+- **Not** an implementation of AirPlay 2 multi-room audio.
+- **Not** a FairPlay/DRM/MFi bypass, and does not touch pairing/authentication code paths.
+- **Not** a claim of full, verified support on real macOS/iOS clients. Automated tests in
+  this change cover CLI parsing and the DNS-SD advertisement construction only; see §5 for
+  what is and isn't covered, and `docs/manual-test-no-audio-advertise.md` for the human
+  verification procedure.
+- **Not** the "display-class" / Mac-model AirPlay reclassification requested in upstream
+  issue #463 (advertising `model=MacBookPro18,3` instead of `AppleTV3,2`, per the
+  reverse-engineered, non-Apple OpenAirPlay spec). That proposal is speculative, untested,
+  has unknown FairPlay/handshake implications per the upstream maintainer's own assessment,
+  and is out of scope here.
+- **Not** the default behavior. `--no-audio-advertise` is opt-in only, precisely because the
+  known-risk teardown behavior described in §4 is unresolved.
+- Does **not** disable audio RTP forwarding (`-artp`) or change `-al` audio latency
+  reporting; those remain independent, orthogonal options.
+
+## 4. Known risks
+
+Upstream (`FDH2/UxPlay`) has already investigated clearing AirPlay feature bit 9
+("audio supported") as a way to get video-only-on-server / audio-stays-on-client behavior:
+
+- **Issues #303 and #442** (duplicates): a user manually cleared feature bit 9 in
+  `uxplay.cpp`, with `_raop._tcp` still registered (i.e., exactly this spec's `bits` mode).
+  Result: audio *does* keep playing on the client throughout the session, but the client
+  sends an RTSP `TEARDOWN` request (stream type 110, "terminate video services") on the
+  mirroring TCP socket almost exactly **60 seconds** (57–58s observed in captured logs)
+  after mirroring starts, ending the video stream. Maintainer `fduncanh` reproduced and
+  confirmed this with full debug logs, and additionally reproduced the **same** ~60s
+  teardown using a completely independent, unrelated third-party AirPlay server
+  implementation (`apsdk`) — leading to the conclusion that this is an AirPlay protocol
+  behavior on the **client** side, not a bug in UxPlay's server code. No workaround was
+  found (a missing "heartbeat"/keepalive was suspected and ruled out — the client sends its
+  own heartbeat every second regardless of the server's audio-support advertisement).
+  Issue #303 was closed by the maintainer as unresolved.
+- **Issue #489**: a duplicate request for the same "video only" behavior. Maintainer
+  confirms the identical ~60s-teardown finding and states plainly: *"we would love to add
+  such a mode, but need someone to discover how to prevent the iOS client requesting a
+  teardown 60 secs after the no-audio mode starts... we have no idea what to do."*
+- **This implementation does not resolve the ~60s teardown.** `--no-audio-advertise bits`
+  (and therefore `both`, which includes it) is expected to reproduce the same known,
+  unresolved teardown behavior described above. It is included anyway because: (a) it's
+  still strictly better than `-a` alone, since the *advertisement* is now honest even if the
+  session eventually tears down; (b) it gives users and future contributors a
+  reproducible, tested baseline matching the exact configuration upstream already
+  characterized.
+- **`raop` mode is untested by upstream.** Skipping `_raop._tcp` registration entirely,
+  either alone or combined with the bit-clearing (`both`), has not been tried in any of the
+  referenced issues. It is unknown whether this changes, avoids, or has no effect on the
+  ~60s teardown, or introduces different client behavior (e.g., at the discovery level
+  rather than the session level). Treat `raop` and `both` as genuinely experimental and
+  unverified until confirmed via `docs/manual-test-no-audio-advertise.md` on real hardware.
+- Because of the above, `--no-audio-advertise` must never become the default, and every
+  startup log message it produces must say "experimental."
+
+## 5. Testing strategy
+
+Automated (see `tests/`):
+
+- CLI parsing / decision logic (`audio_advertise.h`/`.cpp`, pure functions, no I/O):
+  - `-a` alone → local audio disabled, advertisement warning fires, RAOP still registered,
+    feature bits untouched.
+  - `-as 0` alone → same warning fires (a separate code path from `-a`; both are tested
+    independently since the warning is emitted after both have had a chance to run).
+  - Neither `-a`/`-as 0` nor `--no-audio-advertise` → no warnings.
+  - `--no-audio-advertise bits` → RAOP still registered, feature bits cleared.
+  - `--no-audio-advertise raop` → RAOP not registered, feature bits untouched.
+  - `--no-audio-advertise` / `--no-audio-advertise both` → RAOP not registered, feature bits
+    cleared.
+- DNS-SD feature-bitmask construction (`lib/dnssd.c`, pure struct manipulation, no
+  network I/O):
+  - Default bitmask (no options) matches the current, unchanged value
+    (`features1 = 0x527FFEE6`, `features2 = 0x0`).
+  - `hls_support`/`h265_support`/`setup_legacy_pairing` still flip their specific bits, in
+    all combinations — regression coverage for "existing default advertisement must not
+    change."
+  - Applying the no-audio-advertise bit-clearing on top of the default yields exactly
+    `features1 = 0x5243F4E6`, `features2 = 0x0`, and is idempotent.
+- Help text: `uxplay -h` output contains `--no-audio-advertise`.
+
+Explicitly **not** automated (requires real hardware / real mDNS traffic, see
+`docs/manual-test-no-audio-advertise.md`):
+
+- Whether `_raop._tcp` actually disappears from `dns-sd -B _raop._tcp` output on the
+  network.
+- Whether a real macOS/iOS client actually avoids selecting UxPlay as its audio output.
+- Whether the ~60s TEARDOWN occurs, is avoided, or changes timing under `bits`, `raop`, or
+  `both`.
+
+## 6. Engineering note
+
+**What Apple's public documentation confirms.** Two Apple Support articles were reviewed:
+"Stream video and audio with AirPlay" (Mac User Guide,
+`support.apple.com/guide/mac-help/mchld7e543a0/mac`) and "Use AirPlay to stream video or
+mirror the screen of your iPhone or iPad" (`support.apple.com/en-us/102661`). Both describe
+only end-user UI flows: how to start mirroring/streaming from Control Center or an app, and
+the Mac-side "Allow AirPlay for" security setting. **Neither document mentions AirPlay
+feature bits, RAOP, DNS-SD/mDNS TXT record fields, or any distinction between
+"display-class" and "speaker-class" receivers.** Apple does not publish protocol-level
+documentation for AirPlay receiver behavior in any public-facing support content found
+during this investigation.
+
+**What remains undocumented/private.** Everything this change (and the upstream issues it
+draws on) relies on — the meaning of individual feature bits, the RAOP TXT record schema,
+why a client tears down mirroring ~60 seconds after the audio-supported bit is cleared, and
+whether any combination of advertised capabilities avoids that teardown — is reverse-engineered
+knowledge from the AirPlay receiver developer community (this project, `pyatv`, `shairport-sync`,
+`RPiPlay`, the unofficial OpenAirPlay spec, etc.), not Apple documentation. It should be
+treated accordingly: plausible, tested-where-possible, but not authoritative.
+
+**What was tested automatically.** CLI flag recognition and the resulting
+warn/register/clear-bits decisions (`audio_advertise.h`/`.cpp`); the exact resulting AirPlay
+feature bitmask for the default configuration and for each `--no-audio-advertise` mode
+(`lib/dnssd.c`); that existing `hls_support`/`h265_support`/`setup_legacy_pairing` bit
+overrides are unaffected by the refactor that made the bit table testable; that `-h` help
+output documents the new flag.
+
+**What still requires real macOS/iOS validation.** Everything listed under "Explicitly not
+automated" in §5 above — actual client audio-output selection behavior, actual absence of
+`_raop._tcp` on the wire, and actual session teardown timing under each mode. See
+`docs/manual-test-no-audio-advertise.md`.
+
+**Whether the ~60s teardown still happens.** Expected: **yes**, for `bits` and `both` modes,
+since they reproduce the exact configuration (feature bit 9 off) that upstream issues
+#303/#442/#489 already confirmed triggers it, and upstream found no way to avoid it —
+including by testing an independent third-party AirPlay server implementation, which ruled
+out a UxPlay-specific bug. Whether `raop` mode changes this at all is unknown and is exactly
+the open question this change is built to let someone test next.

--- a/specs/no-audio-advertisement.md
+++ b/specs/no-audio-advertisement.md
@@ -47,6 +47,20 @@ Bare `--no-audio-advertise` (no trailing token) is equivalent to `--no-audio-adv
 | `raop` | Skip registration of the `_raop._tcp` service entirely — it will not appear in `dns-sd -B _raop._tcp` output at all. The feature bitmask is left at its normal default. This combination has **not** been tested upstream. |
 | `both` (default) | Both of the above — the narrowest advertisement UxPlay can currently produce that still offers `_airplay._tcp` mirroring. |
 
+The mDNS records are not the only place the advertisement is served from: the RTSP
+`GET /info` handler (`raop_handler_info()` in `lib/raop_handlers.h`) also returns the
+`_airplay._tcp`/`_raop._tcp` TXT record contents inside its plist response — both in the
+Bluetooth LE service-discovery variant (request without a `CSeq` header) and in the
+bplist-`qualifier` variant. Since the raop TXT buffer is only ever built by
+`dnssd_register_raop()`, in `raop`/`both` modes that buffer stays empty, and the handler
+now **omits** an unbuilt/empty TXT record from the response (previously it emitted an
+empty `txtRAOP` data node). The `features` integer in the same `GET /info` response is
+read live from the shared bitmask, so `bits` mode was already reflected on that path.
+This keeps the BLE/`GET /info` discovery surface consistent with the mDNS one, while
+preserving the existing fallback where a *failed* (rather than skipped) `_raop._tcp`
+registration still serves its TXT over BLE: both mDNS backends build the TXT buffer
+before the network registration step, so in that case the buffer is non-empty.
+
 In every mode, `--no-audio-advertise` **implies local audio playback is disabled**
 (`use_audio` is forced to `false`), regardless of `-as <sink>` or argument order. There is no
 way to narrow the advertisement while keeping local playback on — the task and this spec
@@ -109,6 +123,14 @@ Upstream (`FDH2/UxPlay`) has already investigated clearing AirPlay feature bit 9
   ~60s teardown, or introduces different client behavior (e.g., at the discovery level
   rather than the session level). Treat `raop` and `both` as genuinely experimental and
   unverified until confirmed via `docs/manual-test-no-audio-advertise.md` on real hardware.
+- **Feature bit 30 remains set in `raop`/`both` modes.** Bit 30 is documented (both in
+  UxPlay's own bit table and in the OpenAirPlay features table) as "RAOP support: with this
+  bit set, the AirTunes service is not required" — i.e., the client is told the
+  `_airplay._tcp` port itself is a RAOP-capable endpoint. So even with `_raop._tcp`
+  unregistered, a client may still route audio via the unified advertisement. Clearing
+  bit 30 as well is a further untested variant deliberately left out of scope here (a
+  one-line experiment: `dnssd_set_airplay_features(dnssd, 30, 0)`); it is unknown whether
+  clients would still start mirroring at all in that configuration.
 - Because of the above, `--no-audio-advertise` must never become the default, and every
   startup log message it produces must say "experimental."
 
@@ -142,6 +164,11 @@ Explicitly **not** automated (requires real hardware / real mDNS traffic, see
 
 - Whether `_raop._tcp` actually disappears from `dns-sd -B _raop._tcp` output on the
   network.
+- Whether the `GET /info` plist response omits `txtRAOP` in `raop`/`both` modes
+  (`raop_handler_info()` is a static function in a header that pulls in the full raop
+  stack, so it is not unit-testable in this framework-free harness; see the `nc` wire
+  probe in `docs/manual-test-no-audio-advertise.md` §3, which exercises exactly the code
+  path used by BLE service discovery).
 - Whether a real macOS/iOS client actually avoids selecting UxPlay as its audio output.
 - Whether the ~60s TEARDOWN occurs, is avoided, or changes timing under `bits`, `raop`, or
   `both`.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,26 @@
+# UxPlay unit tests.
+#
+# No external test framework is used (no gtest/Catch2): each test is a small,
+# dependency-light executable that asserts and returns 0 on success, non-zero
+# on failure, registered with CTest via add_test().
+
+add_executable( test_audio_advertise_flag
+                 test_audio_advertise_flag.cpp
+                 ${CMAKE_SOURCE_DIR}/audio_advertise.cpp )
+target_include_directories( test_audio_advertise_flag PRIVATE ${CMAKE_SOURCE_DIR} )
+add_test( NAME audio_advertise_flag COMMAND test_audio_advertise_flag )
+
+# Compiles lib/dnssd.c directly (no GStreamer/OpenSSL/network backend needed:
+# dnssd_init()/dnssd_private_init() are never called by these tests).
+add_executable( test_dnssd_features
+                 test_dnssd_features.c
+                 ${CMAKE_SOURCE_DIR}/lib/dnssd.c )
+target_include_directories( test_dnssd_features PRIVATE ${CMAKE_SOURCE_DIR}/lib )
+add_test( NAME dnssd_features COMMAND test_dnssd_features )
+
+# Black-box check that "-h" documents the new flag. "-h" exits 0 via printf+exit(0)
+# before any GStreamer/dnssd initialization, so this is safe/fast on all platforms.
+if ( TARGET uxplay )
+  add_test( NAME help_text COMMAND uxplay -h )
+  set_tests_properties( help_text PROPERTIES PASS_REGULAR_EXPRESSION "no-audio-advertise" )
+endif()

--- a/tests/test_audio_advertise_flag.cpp
+++ b/tests/test_audio_advertise_flag.cpp
@@ -1,0 +1,81 @@
+/* Unit tests for audio_advertise.h pure decision logic. No GStreamer/network
+ * dependency; exercises the predicates that drive --no-audio-advertise and
+ * the -a/-as-0 advertisement warning. See specs/no-audio-advertisement.md. */
+
+#include "audio_advertise.h"
+
+#include <cstdio>
+#include <cstdlib>
+
+static int failures = 0;
+
+#define CHECK(cond, msg)                                                     \
+    do {                                                                     \
+        if (!(cond)) {                                                       \
+            std::fprintf(stderr, "FAIL: %s (%s:%d)\n", msg, __FILE__, __LINE__); \
+            failures++;                                                      \
+        }                                                                    \
+    } while (0)
+
+static void test_flag_recognition() {
+    CHECK(uxplay_is_no_audio_advertise_flag("--no-audio-advertise"), "long flag recognized");
+    CHECK(uxplay_is_no_audio_advertise_flag("-naa"), "short alias recognized");
+    CHECK(!uxplay_is_no_audio_advertise_flag("-a"), "-a is not the new flag");
+    CHECK(!uxplay_is_no_audio_advertise_flag("-as"), "-as is not the new flag");
+    CHECK(!uxplay_is_no_audio_advertise_flag("--no-audio-advertised"), "near-miss string rejected");
+}
+
+static void test_mode_parsing() {
+    bool clear_bits = false, skip_raop = false;
+
+    clear_bits = skip_raop = false;
+    CHECK(uxplay_parse_no_audio_advertise_mode("bits", clear_bits, skip_raop), "bits mode parses");
+    CHECK(clear_bits && !skip_raop, "bits mode: clear bits only");
+
+    clear_bits = skip_raop = false;
+    CHECK(uxplay_parse_no_audio_advertise_mode("raop", clear_bits, skip_raop), "raop mode parses");
+    CHECK(!clear_bits && skip_raop, "raop mode: skip raop only");
+
+    clear_bits = skip_raop = false;
+    CHECK(uxplay_parse_no_audio_advertise_mode("both", clear_bits, skip_raop), "both mode parses");
+    CHECK(clear_bits && skip_raop, "both mode: clear bits and skip raop");
+
+    clear_bits = skip_raop = false;
+    CHECK(!uxplay_parse_no_audio_advertise_mode("bogus", clear_bits, skip_raop), "unrecognized token rejected");
+}
+
+static void test_should_register_raop() {
+    CHECK(uxplay_should_register_raop(false) == true, "raop registered when not skipped");
+    CHECK(uxplay_should_register_raop(true) == false, "raop not registered when skipped");
+}
+
+static void test_warning_predicates() {
+    /* -a alone (or -as 0 alone): use_audio=false, no_audio_advertise=false -> warn */
+    CHECK(uxplay_should_warn_audio_advertise(false, false) == true, "-a alone warns");
+    /* --no-audio-advertise (any mode): no warning needed, advertisement was narrowed */
+    CHECK(uxplay_should_warn_audio_advertise(false, true) == false, "no warning once advertisement narrowed");
+    /* neither flag: default use_audio=true -> no warning */
+    CHECK(uxplay_should_warn_audio_advertise(true, false) == false, "no warning when audio left on");
+    CHECK(uxplay_should_warn_audio_advertise(true, true) == false, "no warning when audio left on (defensive)");
+
+    /* defensive invariant: --no-audio-advertise must force use_audio=false, so this
+     * combination should never legitimately occur, but the predicate must still be correct */
+    CHECK(uxplay_should_warn_audio_still_playing(true, true) == true, "flags audio still on despite no_audio_advertise");
+    CHECK(uxplay_should_warn_audio_still_playing(false, true) == false, "no warning: audio correctly off");
+    CHECK(uxplay_should_warn_audio_still_playing(true, false) == false, "no warning: no_audio_advertise not set");
+    CHECK(uxplay_should_warn_audio_still_playing(false, false) == false, "no warning: neither set");
+}
+
+int main() {
+    test_flag_recognition();
+    test_mode_parsing();
+    test_should_register_raop();
+    test_warning_predicates();
+
+    if (failures) {
+        std::fprintf(stderr, "%d assertion(s) failed\n", failures);
+        return 1;
+    }
+    std::printf("test_audio_advertise_flag: OK\n");
+    return 0;
+}

--- a/tests/test_dnssd_features.c
+++ b/tests/test_dnssd_features.c
@@ -1,0 +1,149 @@
+/* Unit tests for the AirPlay feature-bitmask construction in lib/dnssd.c.
+ * No GStreamer/network dependency: dnssd_t is used as a plain struct here,
+ * dnssd_init()/dnssd_private_init() (which touch the mDNS backend) are never
+ * called. See specs/no-audio-advertisement.md for the exact bit list and the
+ * expected regression values. */
+
+#include "dnssd.h"
+
+#include <stdio.h>
+#include <string.h>
+
+/* dnssd.c also defines dnssd_init()/dnssd_destroy(), which call into the
+ * backend-specific (lib/mdnsd or lib/dns_sd) dnssd_private_init()/
+ * dnssd_private_destroy(). This test never calls dnssd_init()/dnssd_destroy()
+ * (it only exercises pure feature-bitmask functions), but the linker still
+ * requires these symbols to exist since they're referenced from dnssd.c.
+ * These stubs are never actually invoked; they only satisfy the link. */
+void *dnssd_private_init(dnssd_t *dnssd_public, int *error) {
+    (void) dnssd_public;
+    if (error) *error = 0;
+    return NULL;
+}
+
+void dnssd_private_destroy(void *private) {
+    (void) private;
+}
+
+static int failures = 0;
+
+#define CHECK(cond, msg)                                              \
+    do {                                                              \
+        if (!(cond)) {                                                \
+            fprintf(stderr, "FAIL: %s (%s:%d)\n", msg, __FILE__, __LINE__); \
+            failures++;                                               \
+        }                                                             \
+    } while (0)
+
+/* Baseline with hls_support=h265_support=setup_legacy_pairing=0 is
+ * features1=0x527FFEE6, features2=0x0 (verified by hand against the bit
+ * table and cross-checked against the commented alternate FEATURES_1 macro
+ * in lib/dnssdint.h). Only bits 0, 4, 27 (features1) and 42 (features2,
+ * i.e. bit 10 of features2) are expected to move with these three options. */
+static uint64_t expected_default_features(int hls_support, int h265_support, int setup_legacy_pairing) {
+    uint32_t f1 = 0x527FFEE6u;
+    uint32_t f2 = 0x0u;
+
+    if (hls_support) {
+        f1 |= (1u << 0);
+        f1 |= (1u << 4);
+    } else {
+        f1 &= ~(1u << 0);
+        f1 &= ~(1u << 4);
+    }
+
+    if (setup_legacy_pairing) {
+        f1 |= (1u << 27);
+    } else {
+        f1 &= ~((uint32_t)1u << 27);
+    }
+
+    if (h265_support) {
+        f2 |= (1u << (42 - 32));
+    } else {
+        f2 &= ~(1u << (42 - 32));
+    }
+
+    return (((uint64_t) f2) << 32) | (uint64_t) f1;
+}
+
+static void test_default_matches_hand_derived_baseline() {
+    dnssd_t d;
+    memset(&d, 0, sizeof(d));
+    dnssd_set_default_airplay_features(&d, 0, 0, 0);
+    CHECK(d.features1 == 0x527FFEE6u, "default features1 == 0x527FFEE6");
+    CHECK(d.features2 == 0x0u, "default features2 == 0x0");
+    CHECK(dnssd_get_airplay_features(&d) == 0x527FFEE6ULL, "default combined 64-bit value");
+}
+
+static void test_hls_h265_legacy_pairing_matrix() {
+    int hls, h265, legacy;
+    for (hls = 0; hls <= 1; hls++) {
+        for (h265 = 0; h265 <= 1; h265++) {
+            for (legacy = 0; legacy <= 1; legacy++) {
+                dnssd_t d;
+                memset(&d, 0, sizeof(d));
+                dnssd_set_default_airplay_features(&d, hls, h265, legacy);
+                uint64_t got = dnssd_get_airplay_features(&d);
+                uint64_t want = expected_default_features(hls, h265, legacy);
+                if (got != want) {
+                    fprintf(stderr,
+                            "FAIL: hls=%d h265=%d legacy=%d: got 0x%llX want 0x%llX (%s:%d)\n",
+                            hls, h265, legacy,
+                            (unsigned long long) got, (unsigned long long) want,
+                            __FILE__, __LINE__);
+                    failures++;
+                }
+            }
+        }
+    }
+}
+
+static void test_no_audio_advertise_clears_expected_bits() {
+    dnssd_t d;
+    memset(&d, 0, sizeof(d));
+    dnssd_set_default_airplay_features(&d, 0, 0, 0);
+    dnssd_apply_no_audio_advertise(&d);
+    CHECK(d.features1 == 0x5243F4E6u, "no-audio-advertise features1 == 0x5243F4E6");
+    CHECK(d.features2 == 0x0u, "no-audio-advertise features2 unchanged (0x0)");
+
+    /* individual bits: 9, 11, 18, 19, 20, 21 must be off; neighboring bits untouched */
+    CHECK(((d.features1 >> 9) & 1) == 0, "bit 9 (audio supported) cleared");
+    CHECK(((d.features1 >> 11) & 1) == 0, "bit 11 (audio packet redundancy) cleared");
+    CHECK(((d.features1 >> 18) & 1) == 0, "bit 18 (audio format 1) cleared");
+    CHECK(((d.features1 >> 19) & 1) == 0, "bit 19 (audio format 2) cleared");
+    CHECK(((d.features1 >> 20) & 1) == 0, "bit 20 (audio format 3) cleared");
+    CHECK(((d.features1 >> 21) & 1) == 0, "bit 21 (audio format 4) cleared");
+    CHECK(((d.features1 >> 10) & 1) == 1, "bit 10 (unrelated) left untouched");
+    CHECK(((d.features1 >> 22) & 1) == 1, "bit 22 (unrelated) left untouched");
+}
+
+static void test_no_audio_advertise_is_idempotent() {
+    dnssd_t once, twice;
+    memset(&once, 0, sizeof(once));
+    memset(&twice, 0, sizeof(twice));
+
+    dnssd_set_default_airplay_features(&once, 0, 0, 0);
+    dnssd_apply_no_audio_advertise(&once);
+
+    dnssd_set_default_airplay_features(&twice, 0, 0, 0);
+    dnssd_apply_no_audio_advertise(&twice);
+    dnssd_apply_no_audio_advertise(&twice);
+
+    CHECK(once.features1 == twice.features1, "applying twice == applying once (features1)");
+    CHECK(once.features2 == twice.features2, "applying twice == applying once (features2)");
+}
+
+int main() {
+    test_default_matches_hand_derived_baseline();
+    test_hls_h265_legacy_pairing_matrix();
+    test_no_audio_advertise_clears_expected_bits();
+    test_no_audio_advertise_is_idempotent();
+
+    if (failures) {
+        fprintf(stderr, "%d assertion(s) failed\n", failures);
+        return 1;
+    }
+    printf("test_dnssd_features: OK\n");
+    return 0;
+}

--- a/uxplay.1
+++ b/uxplay.1
@@ -137,6 +137,26 @@ UxPlay 1.74: An open\-source AirPlay mirroring (+ audio streaming) server:
 .PP
 .TP
 \fB\-as\fR 0     (or \fB\-a\fR) Turn audio off, streamed video only.
+.IP
+   This only disables local audio playback; it does not change what
+.IP
+   UxPlay advertises, so a client may still route audio to it. See
+.IP
+   \fB\-naa\fR below.
+.TP
+\fB\-naa\fI [mode]\fR  (or \fB\-\-no\-audio\-advertise\fI [mode]\fR) EXPERIMENTAL:
+.IP
+   narrow the AirPlay/DNS-SD advertisement so clients are less likely
+.IP
+   to route audio to UxPlay, instead of only muting local playback.
+.IP
+   Implies \fB\-a\fR. mode is "bits", "raop", or "both" (default "both"
+.IP
+   if mode is omitted). Some AirPlay clients are known to disconnect
+.IP
+   mirroring after 30/60 seconds when audio support is not advertised;
+.IP
+   see specs/no-audio-advertisement.md for details and known risks.
 .TP
 \fB\-al\fR x     Audio latency in seconds (default 0.25) reported to client.
 .TP

--- a/uxplay.cpp
+++ b/uxplay.cpp
@@ -67,6 +67,7 @@
 #include "renderers/video_renderer.h"
 #include "renderers/audio_renderer.h"
 #include "renderers/mux_renderer.h"
+#include "audio_advertise.h"
 #ifdef DBUS
 #include <dbus/dbus.h>
 #endif
@@ -112,6 +113,9 @@ static unsigned char compression_type = 0;
 static std::string audiosink = "autoaudiosink";
 static int  audiodelay = -1;
 static bool use_audio = true;
+static bool no_audio_advertise = false; // --no-audio-advertise [bits|raop|both], see specs/no-audio-advertisement.md
+static bool naa_clear_bits = false;
+static bool naa_skip_raop = false;
 #if __APPLE__
 static bool new_window_closing_behavior = false;
 #else
@@ -969,6 +973,11 @@ static void print_info (char *name) {
     printf("          some choices:pulsesink,alsasink,pipewiresink,jackaudiosink,\n");
     printf("          osssink,oss4sink,osxaudiosink,wasapisink,directsoundsink.\n");
     printf("-as 0     (or -a)  Turn audio off, streamed video only\n");
+    printf("-naa [m]  (or --no-audio-advertise [m]) EXPERIMENTAL: narrow the AirPlay\n");
+    printf("          advertisement so clients are less likely to route audio here;\n");
+    printf("          implies \"-a\". m = \"bits\"|\"raop\"|\"both\" (default \"both\").\n");
+    printf("          May cause some clients to disconnect after 30/60s; see\n");
+    printf("          specs/no-audio-advertisement.md\n");
     printf("-artp pl  Use rtpL16pay to send decoded audio elsewhere: \"pl\"\n");
     printf("          is the remaining pipeline, starting with rtpL16pay options:\n");
     printf("          e.g. \"pt=96 ! udpsink host=127.0.0.1 port=5002\"\n");
@@ -1360,6 +1369,23 @@ static void parse_arguments (int argc, char *argv[]) {
                 use_random_hw_addr  = true;
             }
         } else if (arg == "-a") {
+            use_audio = false;
+        } else if (uxplay_is_no_audio_advertise_flag(arg)) {
+            no_audio_advertise = true;
+            naa_clear_bits = true;
+            naa_skip_raop = true;
+            if (i < argc - 1 && *argv[i+1] != '-') {
+                bool clear_bits = false, skip_raop = false;
+                if (uxplay_parse_no_audio_advertise_mode(argv[i+1], clear_bits, skip_raop)) {
+                    naa_clear_bits = clear_bits;
+                    naa_skip_raop = skip_raop;
+                    i++;
+                } else {
+                    fprintf(stderr, "invalid \"%s %s\": mode must be \"bits\", \"raop\", or \"both\"\n",
+                            arg.c_str(), argv[i+1]);
+                    exit(1);
+                }
+            }
             use_audio = false;
         } else if (arg == "-d") {
             if (i < argc - 1 && *argv[i+1] != '-') {
@@ -1917,15 +1943,19 @@ static int register_dnssd() {
     int dnssd_type = 0;
     uint64_t features;
     
-    dnssd_error = dnssd_register_raop(dnssd, raop_port);
-    if (dnssd_error) {
-        if (ble_filename.empty()) {
-            LOGE("dnssd_register_raop failed with error code %d", dnssd_error);
-            dnssd_error_text(&dnssd_error, appname);
-            return -3;
-        } else {
-            LOGI("dnssd_register_raop failed: ignoring because Bluetooth LE service discovery may be available");
+    if (uxplay_should_register_raop(naa_skip_raop)) {
+        dnssd_error = dnssd_register_raop(dnssd, raop_port);
+        if (dnssd_error) {
+            if (ble_filename.empty()) {
+                LOGE("dnssd_register_raop failed with error code %d", dnssd_error);
+                dnssd_error_text(&dnssd_error, appname);
+                return -3;
+            } else {
+                LOGI("dnssd_register_raop failed: ignoring because Bluetooth LE service discovery may be available");
+            }
         }
+    } else {
+        LOGI("no_audio_advertise: skipping _raop._tcp registration");
     }
 
     dnssd_error = dnssd_register_airplay(dnssd, airplay_port);
@@ -1979,102 +2009,18 @@ static int start_dnssd(std::vector<char> hw_addr, std::string name) {
         return 1;
     }
 
-    /* after dnssd starts, reset the default feature set here 
+    /* after dnssd starts, reset the default feature set here
      * (overwrites features set in dnssdint.h)
-     * default: FEATURES_1 = 0x5A7FFEE6, FEATURES_2 = 0 */
+     * default: FEATURES_1 = 0x5A7FFEE6, FEATURES_2 = 0
+     * bit table lives in lib/dnssd.c (dnssd_set_default_airplay_features) so
+     * it can be unit-tested without GStreamer; see tests/test_dnssd_features.c
+     * and specs/no-audio-advertisement.md. bits 32-63 beyond bit 42 are
+     * unused: see https://emanualcozzi.net/docs/airplay2/features */
+    dnssd_set_default_airplay_features(dnssd, (int) hls_support, (int) h265_support, (int) setup_legacy_pairing);
 
-    dnssd_set_airplay_features(dnssd,  0, 0); // AirPlay video supported 
-    dnssd_set_airplay_features(dnssd,  1, 1); // photo supported 
-    dnssd_set_airplay_features(dnssd,  2, 1); // video protected with FairPlay DRM 
-    dnssd_set_airplay_features(dnssd,  3, 0); // volume control supported for videos
-
-    dnssd_set_airplay_features(dnssd,  4, 0); // http live streaming (HLS) supported
-    dnssd_set_airplay_features(dnssd,  5, 1); // slideshow supported 
-    dnssd_set_airplay_features(dnssd,  6, 1); // 
-    dnssd_set_airplay_features(dnssd,  7, 1); // mirroring supported
-
-    dnssd_set_airplay_features(dnssd,  8, 0); // screen rotation  supported 
-    dnssd_set_airplay_features(dnssd,  9, 1); // audio supported 
-    dnssd_set_airplay_features(dnssd, 10, 1); //  
-    dnssd_set_airplay_features(dnssd, 11, 1); // audio packet redundancy supported
-
-    dnssd_set_airplay_features(dnssd, 12, 1); // FaiPlay secure auth supported 
-    dnssd_set_airplay_features(dnssd, 13, 1); // photo preloading  supported 
-    dnssd_set_airplay_features(dnssd, 14, 1); // Authentication bit 4:  FairPlay authentication
-    dnssd_set_airplay_features(dnssd, 15, 1); // Metadata bit 1 support:   Artwork 
-
-    dnssd_set_airplay_features(dnssd, 16, 1); // Metadata bit 2 support:  Soundtrack  Progress 
-    dnssd_set_airplay_features(dnssd, 17, 1); // Metadata bit 0 support:  Text (DAACP) "Now Playing" info.
-    dnssd_set_airplay_features(dnssd, 18, 1); // Audio format 1 support:   
-    dnssd_set_airplay_features(dnssd, 19, 1); // Audio format 2 support: must be set for AirPlay 2 multiroom audio 
-
-    dnssd_set_airplay_features(dnssd, 20, 1); // Audio format 3 support: must be set for AirPlay 2 multiroom audio 
-    dnssd_set_airplay_features(dnssd, 21, 1); // Audio format 4 support:
-    dnssd_set_airplay_features(dnssd, 22, 1); // Authentication type 4: FairPlay authentication
-    dnssd_set_airplay_features(dnssd, 23, 0); // Authentication type 1: RSA Authentication
-
-    dnssd_set_airplay_features(dnssd, 24, 0); // 
-    dnssd_set_airplay_features(dnssd, 25, 1); // 
-    dnssd_set_airplay_features(dnssd, 26, 0); // Has Unified Advertiser info
-    dnssd_set_airplay_features(dnssd, 27, 1); // Supports Legacy Pairing
-
-    dnssd_set_airplay_features(dnssd, 28, 1); //  
-    dnssd_set_airplay_features(dnssd, 29, 0); // 
-    dnssd_set_airplay_features(dnssd, 30, 1); // RAOP support: with this bit set, the AirTunes service is not required. 
-    dnssd_set_airplay_features(dnssd, 31, 0); // 
-
-
-    /*  bits 32-63: see  https://emanualcozzi.net/docs/airplay2/features 
-    dnssd_set_airplay_features(dnssd, 32, 0); // isCarPlay when ON,; Supports InitialVolume when OFF
-    dnssd_set_airplay_features(dnssd, 33, 0); // Supports Air Play Video Play Queue
-    dnssd_set_airplay_features(dnssd, 34, 0); // Supports Air Play from cloud (requires that bit 6 is ON)
-    dnssd_set_airplay_features(dnssd, 35, 0); // Supports TLS_PSK
-
-    dnssd_set_airplay_features(dnssd, 36, 0); //
-    dnssd_set_airplay_features(dnssd, 37, 0); //
-    dnssd_set_airplay_features(dnssd, 38, 0); //  Supports Unified Media Control (CoreUtils Pairing and Encryption)
-    dnssd_set_airplay_features(dnssd, 39, 0); //
-
-    dnssd_set_airplay_features(dnssd, 40, 0); // Supports Buffered Audio
-    dnssd_set_airplay_features(dnssd, 41, 0); // Supports PTP
-    dnssd_set_airplay_features(dnssd, 42, 0); // Supports Screen Multi Codec (allows h265 video)
-    dnssd_set_airplay_features(dnssd, 43, 0); // Supports System Pairing
-
-    dnssd_set_airplay_features(dnssd, 44, 0); // is AP Valeria Screen Sender
-    dnssd_set_airplay_features(dnssd, 45, 0); //
-    dnssd_set_airplay_features(dnssd, 46, 0); // Supports HomeKit Pairing and Access Control
-    dnssd_set_airplay_features(dnssd, 47, 0); //
-
-    dnssd_set_airplay_features(dnssd, 48, 0); // Supports CoreUtils Pairing and Encryption
-    dnssd_set_airplay_features(dnssd, 49, 0); //
-    dnssd_set_airplay_features(dnssd, 50, 0); // Metadata bit 3: "Now Playing" info sent by bplist not DAACP test
-    dnssd_set_airplay_features(dnssd, 51, 0); // Supports Unified Pair Setup and MFi Authentication
-
-    dnssd_set_airplay_features(dnssd, 52, 0); // Supports Set Peers Extended Message
-    dnssd_set_airplay_features(dnssd, 53, 0); //
-    dnssd_set_airplay_features(dnssd, 54, 0); // Supports AP Sync
-    dnssd_set_airplay_features(dnssd, 55, 0); // Supports WoL
-
-    dnssd_set_airplay_features(dnssd, 56, 0); // Supports Wol
-    dnssd_set_airplay_features(dnssd, 57, 0); //
-    dnssd_set_airplay_features(dnssd, 58, 0); // Supports Hangdog Remote Control
-    dnssd_set_airplay_features(dnssd, 59, 0); // Supports AudioStreamConnection setup
-
-    dnssd_set_airplay_features(dnssd, 60, 0); // Supports Audo Media Data Control         
-    dnssd_set_airplay_features(dnssd, 61, 0); // Supports RFC2198 redundancy
-    */
-
-    /* needed for HLS video support */
-    dnssd_set_airplay_features(dnssd, 0, (int) hls_support);
-    dnssd_set_airplay_features(dnssd, 4, (int) hls_support);
-    // not sure about this one (bit 8, screen rotation supported):
-    //dnssd_set_airplay_features(dnssd, 8, (int) hls_support);
-    
-    /* needed for h265 video support */
-    dnssd_set_airplay_features(dnssd, 42, (int) h265_support);
-
-    /* bit 27 of Features determines whether the AirPlay2 client-pairing protocol will be used (1) or not (0) */
-    dnssd_set_airplay_features(dnssd, 27, (int) setup_legacy_pairing);
+    if (naa_clear_bits) {
+        dnssd_apply_no_audio_advertise(dnssd);
+    }
     return 0;
 }
 
@@ -2997,6 +2943,17 @@ int main (int argc, char *argv[]) {
     if (audiosink == "0") {
         use_audio = false;
         dump_audio = false;
+    }
+    if (uxplay_should_warn_audio_advertise(use_audio, no_audio_advertise)) {
+        LOGI("Audio playback is disabled locally, but UxPlay still advertises audio support. "
+             "macOS/iOS may still route audio to this receiver.");
+    }
+    if (uxplay_should_warn_audio_still_playing(use_audio, no_audio_advertise)) {
+        LOGI("no_audio_advertise is enabled, but local audio playback was not disabled; this should not happen.");
+    }
+    if (no_audio_advertise) {
+        LOGI("Experimental no-audio advertisement mode enabled. Some AirPlay clients may "
+             "disconnect after 30/60 seconds if they require an audio stream during mirroring.");
     }
     if (dump_video) {
         if (video_dump_limit > 0) {


### PR DESCRIPTION
## Summary
- Opt-in, experimental `--no-audio-advertise [bits|raop|both]` option that narrows the AirPlay/DNS-SD advertisement (clearing the feature bits claiming audio support and/or skipping `_raop._tcp` registration) so macOS/iOS are less likely to route audio to UxPlay during mirroring.
- `-a`/`-as 0` behavior is unchanged; they now emit a startup warning explaining they don't affect the advertisement.
- Adds a small CTest-based unit test harness (none existed) covering CLI parsing, exact feature-bitmask values, and help text.
- Adds `specs/no-audio-advertisement.md` and `docs/manual-test-no-audio-advertise.md`.

## Context
Relates to #533, and to the discussion in #303, #442, #463, #489. Clearing the audio-support feature bit (`bits` mode) reproduces the known ~60s client `TEARDOWN` with no fix found — this PR documents that rather than claiming to solve it, and adds a `raop`-only mode (untested before) in case it behaves differently. Opening mainly for feedback given your deeper protocol knowledge here.

## Test plan
- [x] `cmake -B build && cmake --build build --parallel && ctest --test-dir build --output-on-failure` (all green locally)
- [x] Real macOS/iOS mirroring test per the manual test doc — done on real hardware (Ubuntu 25.10 server / macOS `Mac17,3`, srcvers 940.23.1); results in #533 and summarized below

## Update (2026-07-04)
- Pushed 9072b77: the `GET /info` handler now omits a TXT record whose buffer was never built, closing the BLE service-discovery gap @fduncanh pointed out in #533 (an empty `txtRAOP` node was previously returned in `raop`/`both` modes). Wire-verified with a CSeq-less RTSP probe; the failed-registration BLE fallback is unaffected.
- Real-hardware test plan completed (Ubuntu 25.10 server / macOS `Mac17,3` client, srcvers 940.23.1) — full results in #533. Summary: `both` mode achieves the goal (macOS keeps its current audio output; the client doesn't even request a type-96 stream) but reproduces the known client watchdog teardown at ~37–92s; `raop` mode shows `_raop._tcp` is not required for mirroring (bit 30 covers it) but doesn't affect audio routing or the watchdog.
- Follow-up experiment (separate branch, not in this PR): a receiver-initiated "hot audio downgrade" over a newly implemented event channel yields indefinite video-only mirroring — see #533 for details.


## Scope — what this PR is, and what a complete "video-only mirroring" needs

To be upfront about how far this actually gets, after real-hardware testing:

**Solid and mergeable on its own (independent of the audio-routing question):**
- The `GET /info` BLE-path fix (9072b77).
- The CTest unit-test harness (none existed before) + the spec/docs.

**`--no-audio-advertise` is an honest but *incomplete* advertisement lever:** `both` keeps audio on the Mac, but the client tears the video down after ~30–90s (the #303/#442/#489 watchdog). So it is opt-in/experimental and not a standalone "video-only" mode.

**A genuinely working indefinite video-only mirror is possible, but takes two more pieces beyond this PR** (documented in #533; the receiver half is on a separate `event-channel-experiment` branch, intentionally not included here):
1. **Receiver side:** start the session with audio advertised (so the ~60s watchdog never arms), then, mid-session over a newly-implemented AirPlay event channel, send a "downgraded" `updateInfo` (audio feature bits cleared) **and** withdraw `_raop._tcp` / clear the live `_airplay` audio bits. The client then tears down only its audio stream and mirrors video **indefinitely** (verified 240s+, no watchdog). This is new: it defeats the teardown that #303/#442/#489 concluded was unsolvable.
2. **Client side (unavoidable):** macOS does **not** release its audio *output-device selection* when the receiver drops audio — it stays pinned to the now-dead AirPlay device (silence) until something reselects the local output. No receiver-side signal changes this (feature bits, `supportedFormats`, `statusFlags`, mDNS withdrawal all tested negative), and it is not receiver-fixable: even a **real Mac acting as an AirPlay receiver advertises full audio support** (`features=0x4A7FCFD5`, `_raop._tcp` registered) — Apple has no "video-only" receiver mode. So a complete experience needs **either a one-time manual switch of the Mac's audio output back to local, or a small macOS-side CoreAudio helper** that reverts the default output when it becomes AirPlay.

In short: this PR's `--no-audio-advertise` + the event-channel branch get "video mirrors forever, audio stays off the receiver," but the last step (macOS keeping/returning its output to local) is inherently client-side. Happy to take any of this in whatever direction you prefer — merge just the BLE fix + tests, keep the experimental flag, or fold in the event-channel work.
