### PR TITLE
Dispatch the RAOP teardown callback

### DIFF
--- a/lib/raop_handlers.h
+++ b/lib/raop_handlers.h
@@ -1270,6 +1270,10 @@ raop_handler_teardown(raop_conn_t *conn,
     }
     plist_free(req_root_node);
     logger_log(raop->logger, LOGGER_DEBUG, "TEARDOWN request,  96=%d, 110=%d", teardown_96, teardown_110);
+    if (raop->callbacks.conn_teardown) {
+        raop->callbacks.conn_teardown(
+            raop->callbacks.cls, &teardown_96, &teardown_110);
+    }
   
     http_response_add_header(response, "Connection", "close");
   


### PR DESCRIPTION
## Summary

Dispatch the already-declared `raop_callbacks_t::conn_teardown` callback after
UxPlay parses the stream types in an RTSP `TEARDOWN` request.

## Real-world scenario

I started sharing a video to an AirPlay receiver. A moment later I deliberately
stopped sharing and switched playback back to the sender. The sender was no
longer connected to the receiver, but the video handed off to the receiving
player kept running. From a user's point of view the sharing session had ended,
so leaving the old media playing was unexpected.

The technical reason is that UxPlay receives and parses the sender's RTSP
`TEARDOWN`, including whether it applies to audio, video, or the whole session,
but does not dispatch the callback already declared for that event. A callback
consumer therefore cannot tell that the user deliberately ended sharing and
cannot apply its own cleanup policy.

## Problem

`conn_teardown` is part of the public callback structure, but the RAOP handler
never invokes it. Embedders can observe connection creation and destruction,
but cannot distinguish an explicit protocol teardown from a transport-level
disconnect.

That distinction matters for integrations which must:

- stop resources only when the sender deliberately leaves the AirPlay route;
- preserve independently running work across a temporary network loss;
- distinguish audio (`96`), mirrored video (`110`), and full-session teardown.

## Behavior

```mermaid
sequenceDiagram
    participant Sender as AirPlay sender
    participant RAOP as raop_handler_teardown
    participant Consumer as raop_callbacks_t consumer

    Sender->>RAOP: TEARDOWN (streams plist)
    RAOP->>RAOP: Parse type 96 / type 110
    alt conn_teardown is registered
        RAOP->>Consumer: conn_teardown(audio, video)
    end
    RAOP->>RAOP: Existing RTP/HLS cleanup
    RAOP-->>Sender: Response + Connection: close
```

The callback is optional and runs before the existing cleanup logic. No
network behavior, renderer behavior, or teardown ordering changes when it is
not registered.

## Scope

- Four added lines in `lib/raop_handlers.h`.
- No new command-line option.
- No change to the callback ABI.
- No scripts or commands are executed by UxPlay.

## Validation

- [x] Upstream-equivalent Linux build on Ubuntu 24.04:
  `RelWithDebInfo`, `NO_X11_DEPS=OFF`, final `uxplay` artifact verified.
- [x] Headless build on Debian Bookworm:
  `NO_X11_DEPS=ON`, `NO_MARCH_NATIVE=ON`.
- [x] `git diff --check`.
- [ ] Upstream macOS and Windows jobs. GitHub currently marks the workflow
  `action_required` because this is a first-time contribution from a fork;
  a maintainer must approve the run.
- [ ] Physical sender checks for audio-only, video-only, and combined teardown.

UxPlay does not currently provide a CTest/unit-test target for the static RAOP
handlers. Adding a new test framework would be substantially larger than this
four-line callback fix, so this PR keeps that infrastructure out of scope and
lists the protocol cases explicitly.

## Related context

Issue #485 previously discussed connect/disconnect hooks. This PR is narrower:
it only makes the existing protocol callback functional and leaves any policy
or hook implementation to the callback consumer.
