### PR TITLE
Handle direct HTTP media content locations

### DIFF
--- a/lib/http_handlers.h
+++ b/lib/http_handlers.h
@@ -887,9 +887,21 @@ http_handler_play(raop_conn_t *conn, http_request_t *request, http_response_t *r
     }
     set_start_position_seconds(airplay_video, (float) start_position_seconds);
 
-    /* we only support HLS if the playback location is terminated by "/master.m3u8" */
+    /* HLS playlists are proxied through the local FCUP handler. Other HTTP(S)
+     * media can be handed directly to the configured video player. */
     const char *uri_suffix = strstr(playback_location, "/master.m3u8");
-    if (!uri_suffix) { 
+    if (!uri_suffix) {
+        if (!strncmp(playback_location, "http://", strlen("http://")) ||
+            !strncmp(playback_location, "https://", strlen("https://"))) {
+            raop->callbacks.on_video_play(
+                raop->callbacks.cls, playback_location, start_position_seconds);
+            raop_destroy_airplay_video(raop, id);
+            plist_mem_free(playback_location);
+            if (req_root_node) {
+                plist_free(req_root_node);
+            }
+            return;
+        }
         logger_log(raop->logger, LOGGER_ERR, "Content-Location has unsupported form:\n%s\n", playback_location);	    
         goto play_error;
     } else {


### PR DESCRIPTION
## Summary

Pass non-HLS HTTP(S) `Content-Location` values from AirPlay `POST /play`
requests to the existing `on_video_play` callback.

## Real-world scenario

I selected an AirPlay receiver and started a regular video. The sender appeared
to begin sharing, but the receiving screen stayed where it was and playback
never started. There was no useful error visible to the user.

In this case the sender used a direct HTTPS media location, such as a
progressive MP4 file, rather than an HLS URL ending in `/master.m3u8`. UxPlay
rejected the request before the configured player callback could inspect the
media. The same user action can therefore behave differently solely because
the sender selected another valid transport form.

## Problem

The current handler accepts only URLs containing `/master.m3u8`. AirPlay
senders can also provide a direct HTTP(S) media resource, such as an MP4 or
audio/video file. Those requests are rejected before the configured video
player receives the URL, even though UxPlay's existing player callback uses
GStreamer `playbin`, which performs its own format detection.

## Behavior

```mermaid
flowchart TD
    A["POST /play with Content-Location"] --> B{"Contains /master.m3u8?"}
    B -->|"yes"| C["Existing FCUP and local HLS proxy path"]
    B -->|"no"| D{"URL starts with http:// or https://?"}
    D -->|"yes"| E["on_video_play(url, start_position)"]
    E --> F["Destroy incomplete HLS bookkeeping"]
    D -->|"no"| G["Existing 400 Bad Request path"]
```

The HLS path is unchanged. Direct HTTP(S) media is handed to the same callback
used after HLS playlist preparation, and the temporary HLS bookkeeping object
is removed before returning.

## Scope

- One decision branch in `http_handler_play`.
- Reuses the existing `on_video_play` callback and start-position value.
- Accepts only `http://` and `https://`; local files and other schemes remain
  rejected.
- Does not add codec assumptions or a second media player.

## Validation

- [x] Upstream-equivalent Linux build on Ubuntu 24.04:
  `RelWithDebInfo`, `NO_X11_DEPS=OFF`, final `uxplay` artifact verified.
- [x] Headless build on Debian Bookworm:
  `NO_X11_DEPS=ON`, `NO_MARCH_NATIVE=ON`.
- [x] `git diff --check`.
- [ ] Upstream macOS and Windows jobs. GitHub currently marks the workflow
  `action_required` because this is a first-time contribution from a fork;
  a maintainer must approve the run.

## Physical validation still requested

The equivalent handler path has been exercised with direct buffered media in
an external integration, but this exact branch still needs maintainer/device
testing with UxPlay's built-in renderer. Suggested checks:

1. direct MP4 with H.264/AAC;
2. direct audio-only HTTP(S) media;
3. start position other than zero;
4. existing HLS playback to confirm no regression;
5. unsupported scheme to confirm the request remains rejected.

UxPlay does not currently provide a CTest/unit-test target for its static HTTP
handlers. Introducing a test framework and exposing handler internals would be
larger than this focused change, so this PR keeps that infrastructure separate
and provides the explicit behavior matrix above.
