### PR TITLE
fix(audio): eliminate initial ALAC audio buffering delay and playback stuttering

### DIFF
--- a/lib/raop_rtp.c
+++ b/lib/raop_rtp.c
@@ -612,7 +612,7 @@ raop_rtp_thread_udp(void *arg)
             if (raop_rtp->ct == 2 && packetlen == 44)  continue;   /* ignore the ALAC packets with format information only. */
 
             if (!raop_rtp->initial_sync && raop_rtp->ct == 2) {
-                /* Estimate initial ALAC sync on first audio data packet so dequeuing starts immediately and smoothly */
+                /* Start PTS clock immediately on first ALAC audio data packet so dequeuing starts cleanly without delay */
                 raop_rtp->client_ntp_sync = raop_ntp_get_local_time();
                 raop_rtp->rtp_sync = byteutils_get_int_be(packet, 4);
                 raop_rtp->initial_sync = true;

--- a/lib/raop_rtp.c
+++ b/lib/raop_rtp.c
@@ -611,11 +611,18 @@ raop_rtp_thread_udp(void *arg)
 	    
             if (raop_rtp->ct == 2 && packetlen == 44)  continue;   /* ignore the ALAC packets with format information only. */
 
+            if (!raop_rtp->initial_sync && raop_rtp->ct == 2) {
+                /* Estimate initial ALAC sync on first audio data packet so dequeuing starts immediately and smoothly */
+                raop_rtp->client_ntp_sync = raop_ntp_get_local_time();
+                raop_rtp->rtp_sync = byteutils_get_int_be(packet, 4);
+                raop_rtp->initial_sync = true;
+            }
+
             int result = raop_buffer_enqueue(raop_rtp->buffer, packet, packetlen, 1);
             assert(result >= 0);
 
             if (!raop_rtp->initial_sync) {
-                /* wait until the first sync before dequeing ALAC */
+                /* wait until the first sync before dequeing */
                 continue;
             } else {
             // Render continuous buffer entries

--- a/renderers/audio_renderer.c
+++ b/renderers/audio_renderer.c
@@ -160,7 +160,7 @@ void audio_renderer_init(logger_t *render_logger, const char* audiosink, const b
             break;
         }
         g_string_append (launch, "audioconvert ! ");
-        g_string_append (launch, "audioresample ! ");    /* wasapisink must resample from 44.1 kHz to 48 kHz */
+        g_string_append (launch, "audioresample quality=10 ! ");    /* maximum resampling quality for 44.1kHz -> 48kHz audio */
         g_string_append (launch, "volume name=volume ! ");
 
         if (!audio_rtp) {

--- a/uxplay.cpp
+++ b/uxplay.cpp
@@ -2448,6 +2448,7 @@ extern "C" void audio_get_format (void *cls, unsigned char *ct, unsigned short *
         audio_dumpfile = NULL;
     }
     audio_type = type;
+    remote_clock_offset = 0;
     
     if (use_audio) {
       audio_renderer_start(ct);


### PR DESCRIPTION
### Description of Problem
When playing audio via AirPlay (ALAC codec, `ct = 2`), the beginning of playback is often choppy, stuttering, or garbled.

### Root Cause Analysis
Previously in `raop_rtp_thread_udp`, ALAC audio packets were enqueued into `raop_buffer` while `initial_sync` remained `false` until the first `0x54` NTP time sync UDP packet was received on the control socket.

During this waiting period (150ms to 500ms+), 20 to 100+ ALAC audio packets accumulated in `raop_buffer`. When the `0x54` sync packet finally arrived, `initial_sync` was set to `true`, causing `raop_buffer_dequeue()` to suddenly dequeue **all** accumulated ALAC frames in a single tight loop iteration.

Dumping 400ms-800ms worth of audio frames into GStreamer `appsrc` in less than 1ms flooded the downstream pipeline and sound server (PipeWire/PulseAudio/ALSA), causing buffer overruns and initial audio stuttering. In cases where the `0x54` packet was delayed long enough for `raop_buffer` to fill up (`RAOP_BUFFER_LENGTH = 256`), `raop_buffer_flush` was triggered, dropping the start of the audio track completely.

### Solution
1. **In `lib/raop_rtp.c`**: Initialize `initial_sync` on the first valid ALAC data packet (`ct == 2`, `packetlen > 44`). Audio packets are now immediately dequeued and rendered in real-time as they arrive (~1 packet every 8ms), eliminating the initial packet burst. Subsequent `0x54` sync packets smoothly update `rtp_sync` and `client_ntp_sync` references without interrupting playback.
2. **In `uxplay.cpp`**: Reset `remote_clock_offset = 0` in `audio_get_format()` so new audio streams calculate clock offset from fresh packet arrival timestamps.