### PR TITLE
fix: allow playing video from direct Content-Location URLs

### DIFF
--- a/lib/http_handlers.h
+++ b/lib/http_handlers.h
@@ -712,6 +712,11 @@ http_handler_play(raop_conn_t *conn, http_request_t *request, http_response_t *r
     int id = -1;
     id = get_playlist_by_uuid(raop, playback_uuid);
 
+    if (id >= 0 && !get_playback_location(raop->airplay_video[id])) {
+        raop_destroy_airplay_video(raop, id);
+        id = -1;
+    }
+
     /* check if playlist is already downloaded and stored (may have been interrupted by advertisements ) */
     if (id >= 0) {
       //printf("====use EXISTING  airplay_video[%d] %p %s %s\n", id, raop->airplay_video[id], playback_uuid, get_playback_uuid(raop->airplay_video[id]));
@@ -795,9 +800,7 @@ http_handler_play(raop_conn_t *conn, http_request_t *request, http_response_t *r
     }
 
     plist_t req_client_proc_name_node = plist_dict_get_item(req_root_node, "clientProcName");
-    if (!req_client_proc_name_node) {
-        goto play_error;
-    } else {
+    if (req_client_proc_name_node) {
         plist_get_string_val(req_client_proc_name_node, &client_proc_name);
         if (!strstr(supported_hls_proc_names, client_proc_name)){
             logger_log(raop->logger, LOGGER_WARNING, "Unsupported HLS streaming format: clientProcName %s not found in supported list: %s",
@@ -816,12 +819,9 @@ http_handler_play(raop_conn_t *conn, http_request_t *request, http_response_t *r
     }
     set_start_position_seconds(airplay_video, (float) start_position_seconds);
 
-    /* we only support HLS if the playback location is terminated by "/master.m3u8" */
+    /* we support HLS if the playback location is terminated by "/master.m3u8", otherwise pass location to player */
     const char *uri_suffix = strstr(playback_location, "/master.m3u8");
-    if (!uri_suffix) { 
-        logger_log(raop->logger, LOGGER_ERR, "Content-Location has unsupported form:\n%s\n", playback_location);	    
-        goto play_error;
-    } else {
+    if (uri_suffix) {
         size_t len = strlen(get_uri_local_prefix(airplay_video)) + strlen(uri_suffix);
         char *location = (char *) calloc(len + 1, sizeof(char));
         if (!location) {
@@ -839,12 +839,21 @@ http_handler_play(raop_conn_t *conn, http_request_t *request, http_response_t *r
         }
         strcat(uri_prefix, playback_location);
         char *end = strstr(uri_prefix, "/master.m3u8");
-        *end = '\0';						  
+        *end = '\0';
         set_uri_prefix(airplay_video, uri_prefix, strlen(uri_prefix));
         free (uri_prefix);
+        set_next_media_uri_id(airplay_video, 0);
+        fcup_request((void *) conn, playback_location, apple_session_id, get_next_FCUP_RequestID(airplay_video));
+    } else if (!strncmp(playback_location, "http://", strlen("http://")) ||
+               !strncmp(playback_location, "https://", strlen("https://"))) {
+        set_playback_location(airplay_video, playback_location, strlen(playback_location));
+        raop->callbacks.on_video_play(raop->callbacks.cls,
+                                      get_playback_location(airplay_video),
+                                      start_position_seconds);
+    } else {
+        logger_log(raop->logger, LOGGER_ERR, "Content-Location has unsupported form:\n%s\n", playback_location);
+        goto play_error;
     }
-    set_next_media_uri_id(airplay_video, 0);
-    fcup_request((void *) conn, playback_location, apple_session_id, get_next_FCUP_RequestID(airplay_video));
 
     plist_mem_free(playback_location);
 


### PR DESCRIPTION
Senders other than the YouTube app put a direct URL in `Content-Location`, so casting video from them currently fails with 400 even though playbin can play the URL as-is. This PR fixes it, specifically
- A `Content-Location` that does not contain `/master.m3u8` can still work and is now parsed like native receivers: if its a plain `http://` or `https://` URL it is passed directly to `on_video_play`, which playbin plays natively (m3u8, mp4, etc.). The existing YouTube `/master.m3u8` proxy flow is unchanged; only http(s) is accepted, so a sender cannot point playbin at local `file://` URIs
- A missing `clientProcName` key no longer fails the request (senders other than the YouTube app can omit this)

This PR is currently applied [here](https://github.com/jqssun/android-airplay-server).