### PR TITLE
Write -mp4 recordings incrementally, so a crash does not lose the whole file

### DIFF
--- a/renderers/mux_renderer.c
+++ b/renderers/mux_renderer.c
@@ -132,7 +132,27 @@ void mux_renderer_start(void) {
         }
         g_string_append(launch, "mux. ");
     }
-    g_string_append(launch, "mp4mux name=mux ! filesink name=filesink location=");
+    /*
+     * Write the recording incrementally instead of holding it until the muxer
+     * closes the file.
+     *
+     * A default mp4mux keeps everything until EOS, when it finally writes the
+     * moov atom. Nothing reaches the disk before that: a recording killed
+     * after half a minute leaves a zero-byte file, and there is nothing for a
+     * repair tool to work with because the data never left memory. If the
+     * receiver process dies -- and it can, on a GStreamer teardown fault --
+     * the whole session's recording goes with it.
+     *
+     * fragment-mode=first-moov-then-finalise writes a moov up front and then
+     * fragments as it goes, so the file is readable from the first seconds
+     * onward, and on a clean stop it is finalised into an ordinary MP4. So the
+     * normal case still produces a conventional file, and an abrupt death now
+     * costs at most the last fragment instead of everything.
+     */
+    g_string_append(launch,
+                    "mp4mux name=mux fragment-duration=2000 "
+                    "fragment-mode=first-moov-then-finalise "
+                    "! filesink name=filesink location=");
     g_string_append(launch, filename->str);
 
     logger_log(logger, LOGGER_DEBUG, "created Mux pipeline: %s", launch->str);


### PR DESCRIPTION
## What this changes

`-mp4` recordings are now written incrementally instead of being held until the
muxer closes the file. The recording pipeline gains two mp4mux properties:

```
mp4mux name=mux fragment-duration=2000 fragment-mode=first-moov-then-finalise
```

Nothing else changes, and nothing changes at all unless `-mp4` is used.

## The problem

A default `mp4mux` buffers the entire recording and writes the moov atom only
at EOS. This is easy to observe: start a recording, let it run for a minute,
and the file on disk is still zero bytes. Everything is in memory until the
muxer closes the file.

So if the UxPlay process dies, the recording is not truncated -- it is empty.
There is nothing on disk for a repair tool such as `untrunc` to work from,
because the data never reached the disk at all. A session recorded up to the
moment of death is lost in full.

That is not hypothetical. UxPlay can abort on the GStreamer teardown fault that
reports `GLib (gthread-posix.c): Unexpected error from C library during
'pthread_mutex_lock': Invalid argument. Aborting.` when a sender disconnects. On
the current code that fault costs the operator the entire recording, silently
and unrecoverably.

## Why this mode

`fragment-mode=first-moov-then-finalise` writes a moov up front and then writes
fragments as recording proceeds, and on a clean stop it finalises the file into
an ordinary MP4. The normal path therefore still produces a conventional
recording with the same compatibility as before; only the crash path changes,
from "lose everything" to "lose at most the last fragment".

`splitmuxsink` was considered and rejected: it would give bounded loss too, but
it changes how many files a recording produces and what they are called, which
is a much larger change to impose on existing users.

The 2000 ms fragment duration is a starting point rather than a tuned value.
Happy to make the whole thing opt-in behind a flag instead of the default if
you would rather not change existing behaviour -- though the current behaviour
does lose data silently, which is why this is proposed as the default.

## Verification

Built on macOS 27 / Apple Silicon against current master.

The end-to-end check was against a real failure rather than a simulated one.
During testing a receiver aborted on its own with exactly the teardown fault
above, 43 seconds into a mirroring session from an iPad. Immediately afterwards
the recording was intact and readable:

- 1,763,611 bytes, 43.1 s, 843 video packets, 1554x1080 H.264
- frames decoded normally, and carried the wall-clock content expected for when
  they were captured
- trimming a marked interval out of that file produced a normal 23-second clip

The same crash on the unmodified build, on the same machine minutes earlier,
left a zero-byte file.

Sender-side reconnects were also exercised: a sender that drops and reconnects
still closes its segment properly and opens the next one, unchanged from before.
