### PR TITLE
Bound the NAL unit length against the payload before using it

### DIFF
--- a/lib/raop_rtp_mirror.c
+++ b/lib/raop_rtp_mirror.c
@@ -456,7 +456,10 @@ raop_rtp_mirror_thread(void *arg)
                 int nalus_count = 0;
                 while (nalu_size < payload_size) {
                     int nc_len = byteutils_get_int_be(payload_decrypted, nalu_size);
-                    if (nc_len < 0 || nalu_size + 4 > payload_size) {
+                    /* nc_len is read from the payload, so it is only a
+                     * length if the unit it claims fits in what is left. */
+                    if (nc_len < 0 || nalu_size + 4 > payload_size ||
+                        nc_len > payload_size - nalu_size - 4) {
                         valid_data = false;
                         break;
                     }


### PR DESCRIPTION
The NAL walk in raop_rtp_mirror_thread() trusts the 4-byte length prefix to describe a unit that lies within the payload. It checks that the prefix itself is readable, but never that the unit it announces is, so a packet that fails to decrypt yields lengths of any magnitude.

With debug logging on, an SEI/SPS/PPS type then hands that length straight to utils_data_to_string() as a byte count, which reads far past the end of the buffer:

  #0  utils_data_to_string
  #1  raop_rtp_mirror_thread        (SIGSEGV)

A receiver should not die on a stream it cannot decrypt. The loop already knows how to mark a payload as invalid h264, so do that instead.

Found via a mirror stream that decrypted to noise, but the check is worth having regardless of why a payload fails to parse.