### PR TITLE
Reset the AES-CTR residual state when a mirror stream is re-keyed

### DIFF
--- a/lib/mirror_buffer.c
+++ b/lib/mirror_buffer.c
@@ -63,6 +63,16 @@ mirror_buffer_init_aes(mirror_buffer_t *mirror_buffer, const uint64_t *streamCon
     sha_final(ctx, aesiv_video, NULL);
     sha_destroy(ctx);
 
+    /* A re-key means a new stream, so the keystream restarts: any bytes held
+     * back from the previous stream's last partial block must be dropped, or
+     * this stream is decrypted at the wrong offset from its first packet. */
+    mirror_buffer->nextDecryptCount = 0;
+    memset(mirror_buffer->og, 0, sizeof(mirror_buffer->og));
+    if (mirror_buffer->aes_ctx) {
+        aes_ctr_destroy(mirror_buffer->aes_ctx);
+        mirror_buffer->aes_ctx = NULL;
+    }
+
     // Need to be initialized externally
     mirror_buffer->aes_ctx = aes_ctr_init(aeskey_video, aesiv_video);
 }


### PR DESCRIPTION
A sender may restart mirroring inside an RTSP session it never tore down: after a stream TEARDOWN of type 110 it sends only a stream SETUP carrying a fresh streamConnectionID, with no new pair-verify or fp-setup. That path reaches mirror_buffer_init_aes() but not mirror_buffer_init(), so the key and IV are re-derived while nextDecryptCount and og[] still hold the trailing partial block of the previous stream.

mirror_buffer_decrypt() then starts the new stream's first packet at input + nextDecryptCount, so the keystream is offset by up to 15 bytes and every packet decrypts to noise for as long as the session lasts. The unencrypted SPS/PPS packet still parses, so it presents as a corrupt video stream rather than a decryption failure:

  raop_rtp_mirror SPS NAL size = 18
  unexpected non-VCL NAL unit: nalu_type = 16, nalu_size = 500430433

Reset that state on re-key, and free the aes_ctx that was leaked each time.

Reproduced on iOS 18 by mirroring, playing a video in an app that supports AirPlay video, then returning to the home screen so the sender resumes mirroring.