### PR TITLE
Guard against a missing current HLS playlist instead of asserting

### DIFF
--- a/lib/http_handlers.h
+++ b/lib/http_handlers.h
@@ -25,7 +25,11 @@ static void
         logger_log(raop->logger, LOGGER_ERR, "hls_get_current_video: failed to identify current_playlist");
         return NULL;
     }
-    assert(raop->airplay_video[raop->current_video]);
+    if (!raop->airplay_video[raop->current_video]) {
+        logger_log(raop->logger, LOGGER_ERR, "hls_get_current_video: current_playlist %d is empty",
+                   raop->current_video);
+        return NULL;
+    }
     return (void *) raop->airplay_video[raop->current_video];
 }
 
@@ -396,8 +400,7 @@ http_handler_action(raop_conn_t *conn, http_request_t *request, http_response_t 
                     char **response_data, int *response_datalen) {
 
     raop_t *raop = conn->raop;
-    airplay_video_t *airplay_video = (airplay_video_t *) hls_get_current_video(raop);
-    assert(airplay_video);
+    airplay_video_t *airplay_video = NULL;
     bool data_is_plist = false;
     plist_t req_root_node = NULL;
     uint64_t uint_val = 0;
@@ -405,6 +408,12 @@ http_handler_action(raop_conn_t *conn, http_request_t *request, http_response_t 
     int fcup_response_statuscode = 0;
     char *type = NULL;
     bool logger_debug = (logger_get_level(raop->logger) >= LOGGER_DEBUG);
+
+    /* fetched only after the locals above are initialized: post_action_error releases them */
+    airplay_video = (airplay_video_t *) hls_get_current_video(raop);
+    if (!airplay_video) {
+        goto post_action_error;
+    }
 
     const char* session_id = http_request_get_header(request, "X-Apple-Session-ID");
     if (!session_id) {
@@ -721,10 +730,14 @@ http_handler_play(raop_conn_t *conn, http_request_t *request, http_response_t *r
     if (id >= 0) {
       //printf("====use EXISTING  airplay_video[%d] %p %s %s\n", id, raop->airplay_video[id], playback_uuid, get_playback_uuid(raop->airplay_video[id]));
         plist_mem_free(playback_uuid);
+        playback_uuid = NULL;
         plist_free(req_root_node);
+        req_root_node = NULL;
         raop->current_video = id;
         airplay_video = hls_get_current_video(raop);
-        assert(airplay_video);
+        if (!airplay_video) {
+            goto play_error;
+        }
         set_apple_session_id(airplay_video, apple_session_id, strlen(apple_session_id));
         float resume_pos = get_resume_position_seconds(airplay_video);
         float start_pos = get_start_position_seconds(airplay_video);
@@ -767,7 +780,10 @@ http_handler_play(raop_conn_t *conn, http_request_t *request, http_response_t *r
     raop->current_video = id;
     raop->airplay_video[id] = airplay_video_init(raop, raop->port, raop->lang, raop->lang_subtitles, raop->lang_system);
     airplay_video = hls_get_current_video(raop);
-    assert(airplay_video);
+    if (!airplay_video) {
+        plist_mem_free(playback_uuid);
+        goto play_error;
+    }
     set_apple_session_id(airplay_video, apple_session_id, strlen(apple_session_id));
     set_playback_uuid(airplay_video, playback_uuid, strlen(playback_uuid));
     plist_mem_free (playback_uuid);
@@ -902,7 +918,10 @@ http_handler_hls(raop_conn_t *conn,  http_request_t *request, http_response_t *r
         return;
     }
     airplay_video_t *airplay_video = (airplay_video_t *) hls_get_current_video(raop);
-    assert(airplay_video);
+    if (!airplay_video) {
+        http_response_init(response, "HTTP/1.1", 404, "Not Found");
+        return;
+    }
     if (!strcmp(url, "/master.m3u8")){
         char * master_playlist  = get_master_playlist(airplay_video);
         if (master_playlist) {


### PR DESCRIPTION
hls_get_current_video() returns NULL when raop->current_video is negative, but every caller only checked the result with assert(), which a release build compiles out. A POST /action arriving once the current playlist has gone therefore ran on with a NULL airplay_video:

    airplay_video_t *airplay_video = hls_get_current_video(raop);
    assert(airplay_video);                       /* no-op under NDEBUG */
    ...
    const char *apple_session_id = get_apple_session_id(airplay_video);
    if (strcmp(session_id, apple_session_id)){   /* SIGSEGV */

get_apple_session_id() null-checks its argument and returns NULL, so the crash lands inside strcmp() rather than at the dereference.

This is easy to hit from a phone: finishing one AirPlay video and starting another destroys the playlists and leaves current_video at -1, and the sender's next /action request arrives before a new playlist exists. Observed as a repeatable segfault when skipping between podcasts, with "hls_get_current_video: failed to identify current_playlist" logged immediately beforehand.

Return NULL for an empty playlist slot as well, rather than asserting on it, and check the result at each call site: /action and /play answer with the 400 they already use for a malformed request, and the HLS channel answers with the same 404 it already returns when current_video is -1.

In http_handler_action() the fetch moves below the local declarations so that the new goto does not jump over their initialization -- the error path releases type and req_root_node. In http_handler_play() the already-freed playback_uuid and req_root_node are cleared, so reaching play_error cannot double-free req_root_node.