### PR TITLE
Fix Windows mDNS advertising on wrong interface (WSL/Hyper-V)

### DIFF
--- a/lib/mdnsd/mdnsd.c
+++ b/lib/mdnsd/mdnsd.c
@@ -358,14 +358,38 @@ static uint32_t mdns_get_default_ipv4(void)
         return 0;
     }
 
+    /* Prefer routing against a normal (non-multicast) destination: on
+       Windows, connecting to the multicast address itself can resolve to
+       an unrelated virtual adapter (e.g. a WSL/Hyper-V vEthernet
+       interface) instead of the real network adapter, because Windows can
+       make a different routing decision for multicast destinations. No
+       packet is actually sent by connect()/getsockname() on a UDP socket,
+       so this destination does not need to be reachable, only routable. */
     memset(&remote, 0, sizeof(remote));
     remote.sin_family = AF_INET;
-    remote.sin_port = htons(MDNS_PORT);
-    inet_pton(AF_INET, MDNS_ADDR4, &remote.sin_addr);
+    remote.sin_port = htons(53);
+    inet_pton(AF_INET, "8.8.8.8", &remote.sin_addr);
 
     if (connect(fd, (struct sockaddr *) &remote, sizeof(remote)) == 0 &&
         getsockname(fd, (struct sockaddr *) &local, &local_len) == 0) {
         addr = local.sin_addr.s_addr;
+    }
+
+    if (addr == 0) {
+        /* Fall back to the original multicast-address-based lookup, in
+           case the host has no normal internet route (e.g. an isolated
+           LAN with no default gateway) but can still reach the mDNS
+           multicast group. */
+        memset(&remote, 0, sizeof(remote));
+        remote.sin_family = AF_INET;
+        remote.sin_port = htons(MDNS_PORT);
+        inet_pton(AF_INET, MDNS_ADDR4, &remote.sin_addr);
+
+        local_len = sizeof(local);
+        if (connect(fd, (struct sockaddr *) &remote, sizeof(remote)) == 0 &&
+            getsockname(fd, (struct sockaddr *) &local, &local_len) == 0) {
+            addr = local.sin_addr.s_addr;
+        }
     }
 
     CLOSESOCKET(fd);


### PR DESCRIPTION
## Summary
`mdns_get_default_ipv4()` can pick the wrong network adapter on Windows when a WSL/Hyper-V virtual switch is present, so the AirPlay mDNS advertisement never reaches the real LAN and the server doesn't appear in the AirPlay picker — even though the socket binds fine and `register_dnssd` reports success.

## Problem
**Environment:** Windows 11, native MSYS2/UCRT64 build, with WSL installed alongside a real Wi-Fi adapter.

`mdns_get_default_ipv4()` finds the local IP to advertise by opening a UDP socket, `connect()`-ing it to the mDNS multicast address (224.0.0.251), and reading back the local address with `getsockname()`. On this kind of Windows machine, that call can resolve to the WSL/Hyper-V vEthernet virtual adapter instead of the real Wi-Fi/Ethernet adapter, because Windows makes a different routing decision for multicast destinations than for normal unicast traffic. The internal mDNS responder ends up binding/advertising using the virtual adapter's IP, which sits on an isolated virtual network the iPhone/client never sees.

## Solution
Resolve the local IP by connecting to a normal unicast destination (`8.8.8.8:53`, no packet is actually sent — `connect()`/`getsockname()` on a UDP socket only does a routing-table lookup) instead of the mDNS multicast address. This follows the same route the system uses for ordinary internet traffic. If that lookup fails (e.g. a host with no default gateway at all), it falls back to the original multicast-based lookup.

**Compatibility:**
- No extra virtual adapters (common case): old and new lookup resolve to the same (only) real adapter — unchanged.
- WSL/Hyper-V/VMware present (the case this fixes): new lookup now picks the real adapter instead of the virtual one.
- No normal internet route at all: falls back to the exact old behavior.

## Testing
Reproduced and verified the underlying lookup with a Python snippet mirroring the exact `connect()`/`getsockname()` logic, before and after:
```python
import socket
s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
s.connect(('224.0.0.251', 5353))   # old destination
print(s.getsockname()[0])           # -> 172.17.64.1 (WSL vEthernet, wrong)

s2 = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
s2.connect(('8.8.8.8', 53))         # new destination
print(s2.getsockname()[0])          # -> 192.168.x.x (real Wi-Fi adapter, correct)
```
- Built with MSYS2 UCRT64 (`cmake -G Ninja .. && ninja`) on Windows 11 with WSL installed
- Before: UxPlay started normally and logged `register_dnssd: advertised AirPlay service`, but never showed up in the iPhone's AirPlay device list
- After: same setup, iPhone finds and successfully mirrors to the Windows PC
- Confirmed via `netstat` / `netsh interface ipv4 show joins` that the mDNS UDP socket and multicast group membership use the real Wi-Fi adapter's IP after the fix
