### PR TITLE
Unref the system clock once, not once per audio format

### DIFF
--- a/renderers/audio_renderer.c
+++ b/renderers/audio_renderer.c
@@ -234,8 +234,18 @@ void audio_renderer_init(logger_t *render_logger, const char* audiosink, const b
         g_string_free(launch, TRUE);
         g_object_set(renderer_type[i]->appsrc, "caps", caps, "stream-type", 0, "is-live", TRUE, "format", GST_FORMAT_TIME, NULL);
         gst_caps_unref(caps);
-        g_object_unref(clock);
     }
+    /* One gst_system_clock_obtain() above, so one unref -- and here, not inside
+       the loop. Each iteration's gst_pipeline_use_clock() takes a reference of
+       its own that the pipeline owns and releases with itself; unreffing per
+       iteration therefore released our single reference on the first pass and a
+       pipeline's on the second.  Nothing goes wrong during initialisation -- the
+       static singleton reference keeps the clock alive -- but the deficit is
+       carried to TEARDOWN: with NFORMATS pipelines each dropping the reference
+       they own, disposing them all exhausts the clock's references, static one
+       included, while anything else still holding a pointer to it does not know.
+       Raising NFORMATS (the comment on it invites 4) makes the deficit larger. */
+    g_object_unref(clock);
 }
 
 void audio_renderer_stop() {


### PR DESCRIPTION
`audio_renderer_init()` calls `gst_system_clock_obtain()` once, before the loop
over `NFORMATS`, and `g_object_unref(clock)` inside it. Each iteration also
calls `gst_pipeline_use_clock()`, which takes a reference the pipeline owns and
releases when it is disposed. So the per-iteration unref drops our single
reference on the first pass and one of the pipelines' on the second.

Initialisation looks fine, because `GstSystemClock` is a singleton holding a
static reference that keeps it alive. The deficit is carried to teardown: with
`NFORMATS` pipelines each releasing the reference they believe they own,
disposing them all exhausts the clock's references — the static one included —
while anything else still holding a pointer to it has no idea. Raising
`NFORMATS`, which the comment on the define invites, makes the deficit larger.

Reproduced the ownership sequence against GStreamer 1.29 with two empty
pipelines: the original sequence disposes the clock during pipeline teardown,
the fixed one retains it; neither disposes it during initialisation.

One obtain, one unref, after the loop.
